### PR TITLE
Expose internal fields of configuration structs.

### DIFF
--- a/config/aggregate.go
+++ b/config/aggregate.go
@@ -20,16 +20,21 @@ type AggregateConfig struct {
 	// Configure() method.
 	HandlerIdentity identity.Identity
 
-	consumed message.RoleMap
-	produced message.RoleMap
+	// Consumed is a map of message type to role for those message types
+	// consumed by this handler.
+	Consumed message.RoleMap
+
+	// Produced is a map of message type to role for those message types
+	// produced by this handler.
+	Produced message.RoleMap
 }
 
 // NewAggregateConfig returns an AggregateConfig for the given handler.
 func NewAggregateConfig(h dogma.AggregateMessageHandler) (*AggregateConfig, error) {
 	cfg := &AggregateConfig{
 		Handler:  h,
-		consumed: message.RoleMap{},
-		produced: message.RoleMap{},
+		Consumed: message.RoleMap{},
+		Produced: message.RoleMap{},
 	}
 
 	c := &aggregateConfigurer{
@@ -49,14 +54,14 @@ func NewAggregateConfig(h dogma.AggregateMessageHandler) (*AggregateConfig, erro
 		)
 	}
 
-	if len(c.cfg.consumed) == 0 {
+	if len(c.cfg.Consumed) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call AggregateConfigurer.ConsumesCommandType()",
 			h,
 		)
 	}
 
-	if len(c.cfg.produced) == 0 {
+	if len(c.cfg.Produced) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call AggregateConfigurer.ProducesEventType()",
 			h,
@@ -83,12 +88,12 @@ func (c *AggregateConfig) HandlerReflectType() reflect.Type {
 
 // ConsumedMessageTypes returns the message types consumed by the handler.
 func (c *AggregateConfig) ConsumedMessageTypes() message.RoleMap {
-	return c.consumed
+	return c.Consumed
 }
 
 // ProducedMessageTypes returns the message types produced by the handler.
 func (c *AggregateConfig) ProducedMessageTypes() message.RoleMap {
-	return c.produced
+	return c.Produced
 }
 
 // Accept calls v.VisitAggregateConfig(ctx, c).
@@ -125,7 +130,7 @@ func (c *aggregateConfigurer) Identity(n, k string) {
 }
 
 func (c *aggregateConfigurer) ConsumesCommandType(m dogma.Message) {
-	if !c.cfg.consumed.AddM(m, message.CommandRole) {
+	if !c.cfg.Consumed.AddM(m, message.CommandRole) {
 		panicf(
 			`%T.Configure() has already called AggregateConfigurer.ConsumesCommandType(%T)`,
 			c.cfg.Handler,
@@ -135,7 +140,7 @@ func (c *aggregateConfigurer) ConsumesCommandType(m dogma.Message) {
 }
 
 func (c *aggregateConfigurer) ProducesEventType(m dogma.Message) {
-	if !c.cfg.produced.AddM(m, message.EventRole) {
+	if !c.cfg.Produced.AddM(m, message.EventRole) {
 		panicf(
 			`%T.Configure() has already called AggregateConfigurer.ProducesEventType(%T)`,
 			c.cfg.Handler,

--- a/config/aggregate.go
+++ b/config/aggregate.go
@@ -13,6 +13,7 @@ import (
 // AggregateConfig represents the configuration of an aggregate message handler.
 type AggregateConfig struct {
 	// Handler is the handler that the configuration applies to.
+	// It is nil if the config was obtained via the config API.
 	Handler dogma.AggregateMessageHandler
 
 	// HandlerIdentity is the handler's identity, as specified by its

--- a/config/application.go
+++ b/config/application.go
@@ -11,6 +11,7 @@ import (
 // ApplicationConfig represents the configuration of an entire Dogma application.
 type ApplicationConfig struct {
 	// Application is the application that the configuration applies to.
+	// It is nil if the config was obtained via the config API.
 	Application dogma.Application
 
 	// ApplicationIdentity is the application's identity, as specified by its

--- a/config/integration.go
+++ b/config/integration.go
@@ -13,6 +13,7 @@ import (
 // IntegrationConfig represents the configuration of an integration message handler.
 type IntegrationConfig struct {
 	// Handler is the handler that the configuration applies to.
+	// It is nil if the config was obtained via the config API.
 	Handler dogma.IntegrationMessageHandler
 
 	// HandlerIdentity is the handler's identity, as specified by its

--- a/config/integration.go
+++ b/config/integration.go
@@ -20,16 +20,21 @@ type IntegrationConfig struct {
 	// Configure() method.
 	HandlerIdentity identity.Identity
 
-	consumed message.RoleMap
-	produced message.RoleMap
+	// Consumed is a map of message type to role for those message types
+	// consumed by this handler.
+	Consumed message.RoleMap
+
+	// Produced is a map of message type to role for those message types
+	// produced by this handler.
+	Produced message.RoleMap
 }
 
 // NewIntegrationConfig returns an IntegrationConfig for the given handler.
 func NewIntegrationConfig(h dogma.IntegrationMessageHandler) (*IntegrationConfig, error) {
 	cfg := &IntegrationConfig{
 		Handler:  h,
-		consumed: message.RoleMap{},
-		produced: message.RoleMap{},
+		Consumed: message.RoleMap{},
+		Produced: message.RoleMap{},
 	}
 
 	c := &integrationConfigurer{
@@ -49,7 +54,7 @@ func NewIntegrationConfig(h dogma.IntegrationMessageHandler) (*IntegrationConfig
 		)
 	}
 
-	if len(c.cfg.consumed) == 0 {
+	if len(c.cfg.Consumed) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call IntegrationConfigurer.ConsumesCommandType()",
 			h,
@@ -76,12 +81,12 @@ func (c *IntegrationConfig) HandlerReflectType() reflect.Type {
 
 // ConsumedMessageTypes returns the message types consumed by the handler.
 func (c *IntegrationConfig) ConsumedMessageTypes() message.RoleMap {
-	return c.consumed
+	return c.Consumed
 }
 
 // ProducedMessageTypes returns the message types produced by the handler.
 func (c *IntegrationConfig) ProducedMessageTypes() message.RoleMap {
-	return c.produced
+	return c.Produced
 }
 
 // Accept calls v.VisitIntegrationConfig(ctx, c).
@@ -118,7 +123,7 @@ func (c *integrationConfigurer) Identity(n, k string) {
 }
 
 func (c *integrationConfigurer) ConsumesCommandType(m dogma.Message) {
-	if !c.cfg.consumed.AddM(m, message.CommandRole) {
+	if !c.cfg.Consumed.AddM(m, message.CommandRole) {
 		panicf(
 			`%T.Configure() has already called IntegrationConfigurer.ConsumesCommandType(%T)`,
 			c.cfg.Handler,
@@ -128,7 +133,7 @@ func (c *integrationConfigurer) ConsumesCommandType(m dogma.Message) {
 }
 
 func (c *integrationConfigurer) ProducesEventType(m dogma.Message) {
-	if !c.cfg.produced.AddM(m, message.EventRole) {
+	if !c.cfg.Produced.AddM(m, message.EventRole) {
 		panicf(
 			`%T.Configure() has already called IntegrationConfigurer.ProducesEventType(%T)`,
 			c.cfg.Handler,

--- a/config/process.go
+++ b/config/process.go
@@ -13,6 +13,7 @@ import (
 // ProcessConfig represents the configuration of an process message handler.
 type ProcessConfig struct {
 	// Handler is the handler that the configuration applies to.
+	// It is nil if the config was obtained via the config API.
 	Handler dogma.ProcessMessageHandler
 
 	// HandlerIdentity is the handler's identity, as specified by its

--- a/config/process.go
+++ b/config/process.go
@@ -20,16 +20,21 @@ type ProcessConfig struct {
 	// Configure() method.
 	HandlerIdentity identity.Identity
 
-	consumed message.RoleMap
-	produced message.RoleMap
+	// Consumed is a map of message type to role for those message types
+	// consumed by this handler.
+	Consumed message.RoleMap
+
+	// Produced is a map of message type to role for those message types
+	// produced by this handler.
+	Produced message.RoleMap
 }
 
 // NewProcessConfig returns an ProcessConfig for the given handler.
 func NewProcessConfig(h dogma.ProcessMessageHandler) (*ProcessConfig, error) {
 	cfg := &ProcessConfig{
 		Handler:  h,
-		consumed: message.RoleMap{},
-		produced: message.RoleMap{},
+		Consumed: message.RoleMap{},
+		Produced: message.RoleMap{},
 	}
 
 	c := &processConfigurer{
@@ -49,14 +54,14 @@ func NewProcessConfig(h dogma.ProcessMessageHandler) (*ProcessConfig, error) {
 		)
 	}
 
-	if len(c.cfg.consumed) == 0 {
+	if len(c.cfg.Consumed) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call ProcessConfigurer.ConsumesEventType()",
 			h,
 		)
 	}
 
-	if len(c.cfg.produced) == 0 {
+	if len(c.cfg.Produced) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call ProcessConfigurer.ProducesCommandType()",
 			h,
@@ -83,12 +88,12 @@ func (c *ProcessConfig) HandlerReflectType() reflect.Type {
 
 // ConsumedMessageTypes returns the message types consumed by the handler.
 func (c *ProcessConfig) ConsumedMessageTypes() message.RoleMap {
-	return c.consumed
+	return c.Consumed
 }
 
 // ProducedMessageTypes returns the message types produced by the handler.
 func (c *ProcessConfig) ProducedMessageTypes() message.RoleMap {
-	return c.produced
+	return c.Produced
 }
 
 // Accept calls v.VisitProcessConfig(ctx, c).
@@ -125,16 +130,16 @@ func (c *processConfigurer) Identity(n, k string) {
 }
 
 func (c *processConfigurer) ConsumesEventType(m dogma.Message) {
-	c.add(c.cfg.consumed, m, message.EventRole)
+	c.add(c.cfg.Consumed, m, message.EventRole)
 }
 
 func (c *processConfigurer) ProducesCommandType(m dogma.Message) {
-	c.add(c.cfg.produced, m, message.CommandRole)
+	c.add(c.cfg.Produced, m, message.CommandRole)
 }
 
 func (c *processConfigurer) SchedulesTimeoutType(m dogma.Message) {
-	c.add(c.cfg.consumed, m, message.TimeoutRole)
-	c.add(c.cfg.produced, m, message.TimeoutRole)
+	c.add(c.cfg.Consumed, m, message.TimeoutRole)
+	c.add(c.cfg.Produced, m, message.TimeoutRole)
 }
 
 func (c *processConfigurer) add(rm message.RoleMap, m dogma.Message, r message.Role) {

--- a/config/projection.go
+++ b/config/projection.go
@@ -13,6 +13,7 @@ import (
 // ProjectionConfig represents the configuration of an aggregate message handler.
 type ProjectionConfig struct {
 	// Handler is the handler that the configuration applies to.
+	// It is nil if the config was obtained via the config API.
 	Handler dogma.ProjectionMessageHandler
 
 	// HandlerIdentity is the handler's identity, as specified by its

--- a/config/projection.go
+++ b/config/projection.go
@@ -20,14 +20,16 @@ type ProjectionConfig struct {
 	// Configure() method.
 	HandlerIdentity identity.Identity
 
-	consumed message.RoleMap
+	// Consumed is a map of message type to role for those message types
+	// consumed by this handler.
+	Consumed message.RoleMap
 }
 
 // NewProjectionConfig returns an ProjectionConfig for the given handler.
 func NewProjectionConfig(h dogma.ProjectionMessageHandler) (*ProjectionConfig, error) {
 	cfg := &ProjectionConfig{
 		Handler:  h,
-		consumed: message.RoleMap{},
+		Consumed: message.RoleMap{},
 	}
 
 	c := &projectionConfigurer{
@@ -47,7 +49,7 @@ func NewProjectionConfig(h dogma.ProjectionMessageHandler) (*ProjectionConfig, e
 		)
 	}
 
-	if len(c.cfg.consumed) == 0 {
+	if len(c.cfg.Consumed) == 0 {
 		return nil, errorf(
 			"%T.Configure() did not call ProjectionConfigurer.ConsumesEventType()",
 			h,
@@ -74,7 +76,7 @@ func (c *ProjectionConfig) HandlerReflectType() reflect.Type {
 
 // ConsumedMessageTypes returns the message types consumed by the handler.
 func (c *ProjectionConfig) ConsumedMessageTypes() message.RoleMap {
-	return c.consumed
+	return c.Consumed
 }
 
 // ProducedMessageTypes returns the message types produced by the handler.
@@ -116,7 +118,7 @@ func (c *projectionConfigurer) Identity(n, k string) {
 }
 
 func (c *projectionConfigurer) ConsumesEventType(m dogma.Message) {
-	if !c.cfg.consumed.AddM(m, message.EventRole) {
+	if !c.cfg.Consumed.AddM(m, message.EventRole) {
 		panicf(
 			`%T.Configure() has already called ProjectionConfigurer.ConsumesEventType(%T)`,
 			c.cfg.Handler,


### PR DESCRIPTION
This is in preparation for #36, which needs to be able to construct the config values without having access to the actual implementations of the Dogma application and handler interfaces.