### PR TITLE
Refactor envelope packing and extension handling

### DIFF
--- a/protobuf/envelopepb/envelope.go
+++ b/protobuf/envelopepb/envelope.go
@@ -3,6 +3,8 @@ package envelopepb
 import (
 	"errors"
 	"fmt"
+
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // Validate returns an error if x is not well-formed.
@@ -130,6 +132,14 @@ func (x *Header) validate() error {
 		return fmt.Errorf("invalid source: %w", err)
 	}
 
+	if err := validateAnyValues("extensions", x.Extensions); err != nil {
+		return err
+	}
+
+	if err := validateAnyValues("baggage", x.Baggage); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -160,6 +170,32 @@ func (x *Body) validate(header *Header) error {
 
 	if err := x.GetMessage().validate(); err != nil {
 		return fmt.Errorf("invalid message: %w", err)
+	}
+
+	if err := validateAnyValues("extensions", x.Extensions); err != nil {
+		return err
+	}
+
+	if err := validateAnyValues("baggage", x.Baggage); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAnyValues(name string, values []*anypb.Any) error {
+	for i, v := range values {
+		if err := validateAnyValue(v); err != nil {
+			return fmt.Errorf("invalid %s at index %d: %w", name, i, err)
+		}
+	}
+
+	return nil
+}
+
+func validateAnyValue(v *anypb.Any) error {
+	if v.GetTypeUrl() == "" {
+		return errors.New("type URL must not be empty")
 	}
 
 	return nil

--- a/protobuf/envelopepb/envelope.pb.go
+++ b/protobuf/envelopepb/envelope.pb.go
@@ -11,6 +11,7 @@ import (
 	uuidpb "github.com/dogmatiq/enginekit/protobuf/uuidpb"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
@@ -284,67 +285,6 @@ func (x *Message) GetData() []byte {
 	return nil
 }
 
-// Extensions is a container for arbitrary key/value pairs associated with a
-// message and/or its causal chain.
-//
-// Keys beginning with "_" are reserved for use by the enginekit module. All
-// other keys SHOULD use reverse-domain notation, e.g. "com.example.some-key".
-type Extensions struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// Attributes is a set of arbitrary key/value pairs that provide additional
-	// information about the message.
-	Attributes map[string]string `protobuf:"bytes,1,rep,name=attributes,proto3" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Baggage is a set of arbitrary key/value pairs that are propagated through
-	// the entire causal chain of messages.
-	Baggage       map[string]string `protobuf:"bytes,2,rep,name=baggage,proto3" json:"baggage,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *Extensions) Reset() {
-	*x = Extensions{}
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *Extensions) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*Extensions) ProtoMessage() {}
-
-func (x *Extensions) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use Extensions.ProtoReflect.Descriptor instead.
-func (*Extensions) Descriptor() ([]byte, []int) {
-	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *Extensions) GetAttributes() map[string]string {
-	if x != nil {
-		return x.Attributes
-	}
-	return nil
-}
-
-func (x *Extensions) GetBaggage() map[string]string {
-	if x != nil {
-		return x.Baggage
-	}
-	return nil
-}
-
 type Header struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// CausationId is the (optional) ID of the message that was the direct cause
@@ -362,16 +302,19 @@ type Header struct {
 	CorrelationId *uuidpb.UUID `protobuf:"bytes,2,opt,name=correlation_id,json=correlationId,proto3" json:"correlation_id,omitempty"`
 	// Source identifies the origin of the messages.
 	Source *Source `protobuf:"bytes,3,opt,name=source,proto3" json:"source,omitempty"`
-	// Extensions is a container for arbitrary key/value pairs associated with
-	// the messages, their causal chain, or the envelope itself.
-	Extensions    *Extensions `protobuf:"bytes,4,opt,name=extensions,proto3" json:"extensions,omitempty"`
+	// Extensions is a set of extension values associated with the messages,
+	// their causal chain, or the envelope itself.
+	Extensions []*anypb.Any `protobuf:"bytes,4,rep,name=extensions,proto3" json:"extensions,omitempty"`
+	// Baggage is a set of extension values that are propagated through the
+	// entire causal chain of messages.
+	Baggage       []*anypb.Any `protobuf:"bytes,5,rep,name=baggage,proto3" json:"baggage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Header) Reset() {
 	*x = Header{}
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[5]
+	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -383,7 +326,7 @@ func (x *Header) String() string {
 func (*Header) ProtoMessage() {}
 
 func (x *Header) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[5]
+	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -396,7 +339,7 @@ func (x *Header) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Header.ProtoReflect.Descriptor instead.
 func (*Header) Descriptor() ([]byte, []int) {
-	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescGZIP(), []int{5}
+	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Header) GetCausationId() *uuidpb.UUID {
@@ -420,13 +363,22 @@ func (x *Header) GetSource() *Source {
 	return nil
 }
 
-func (x *Header) GetExtensions() *Extensions {
+func (x *Header) GetExtensions() []*anypb.Any {
 	if x != nil {
 		return x.Extensions
 	}
 	return nil
 }
 
+func (x *Header) GetBaggage() []*anypb.Any {
+	if x != nil {
+		return x.Baggage
+	}
+	return nil
+}
+
+// Body contains the metadata and encoded form of a single message in an
+// [Envelope] or [MultiEnvelope].
 type Body struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// MessageId is a unique identifier for the message in this envelope.
@@ -447,19 +399,24 @@ type Body struct {
 	ScheduledFor *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=scheduled_for,json=scheduledFor,proto3" json:"scheduled_for,omitempty"`
 	// Message is the encoded representation of the [dogma.Message].
 	Message *Message `protobuf:"bytes,5,opt,name=message,proto3" json:"message,omitempty"`
-	// Extensions is a container for arbitrary key/value pairs associated with
-	// this message and/or its causal chain.
+	// Extensions is a set of extension values associated with this message.
 	//
-	// Any keys present in the [Header.Extensions] field are overridden by keys
-	// in this field.
-	Extensions    *Extensions `protobuf:"bytes,6,opt,name=extensions,proto3" json:"extensions,omitempty"`
+	// Any values in [Header.Extensions] are overridden by values in this field
+	// that have the same type URL.
+	Extensions []*anypb.Any `protobuf:"bytes,6,rep,name=extensions,proto3" json:"extensions,omitempty"`
+	// Baggage is a set of extension values associated with this message and/or
+	// its causal chain.
+	//
+	// Any values in [Header.Baggage] are overridden by values in this field
+	// that have the same type URL.
+	Baggage       []*anypb.Any `protobuf:"bytes,7,rep,name=baggage,proto3" json:"baggage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Body) Reset() {
 	*x = Body{}
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[6]
+	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -471,7 +428,7 @@ func (x *Body) String() string {
 func (*Body) ProtoMessage() {}
 
 func (x *Body) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[6]
+	mi := &file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -484,7 +441,7 @@ func (x *Body) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Body.ProtoReflect.Descriptor instead.
 func (*Body) Descriptor() ([]byte, []int) {
-	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescGZIP(), []int{6}
+	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Body) GetMessageId() *uuidpb.UUID {
@@ -522,9 +479,16 @@ func (x *Body) GetMessage() *Message {
 	return nil
 }
 
-func (x *Body) GetExtensions() *Extensions {
+func (x *Body) GetExtensions() []*anypb.Any {
 	if x != nil {
 		return x.Extensions
+	}
+	return nil
+}
+
+func (x *Body) GetBaggage() []*anypb.Any {
+	if x != nil {
+		return x.Baggage
 	}
 	return nil
 }
@@ -533,7 +497,7 @@ var File_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto protor
 
 const file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDesc = "" +
 	"\n" +
-	"@github.com/dogmatiq/enginekit/protobuf/envelopepb/envelope.proto\x12\x0edogma.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a@github.com/dogmatiq/enginekit/protobuf/identitypb/identity.proto\x1a8github.com/dogmatiq/enginekit/protobuf/uuidpb/uuid.proto\"d\n" +
+	"@github.com/dogmatiq/enginekit/protobuf/envelopepb/envelope.proto\x12\x0edogma.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19google/protobuf/any.proto\x1a@github.com/dogmatiq/enginekit/protobuf/identitypb/identity.proto\x1a8github.com/dogmatiq/enginekit/protobuf/uuidpb/uuid.proto\"d\n" +
 	"\bEnvelope\x12.\n" +
 	"\x06header\x18\x01 \x01(\v2\x16.dogma.protobuf.HeaderR\x06header\x12(\n" +
 	"\x04body\x18\x02 \x01(\v2\x14.dogma.protobuf.BodyR\x04body\"m\n" +
@@ -549,26 +513,15 @@ const file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawD
 	"\aMessage\x12-\n" +
 	"\atype_id\x18\x01 \x01(\v2\x14.dogma.protobuf.UUIDR\x06typeId\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x12\n" +
-	"\x04data\x18\x03 \x01(\fR\x04data\"\x96\x02\n" +
-	"\n" +
-	"Extensions\x12J\n" +
-	"\n" +
-	"attributes\x18\x01 \x03(\v2*.dogma.protobuf.Extensions.AttributesEntryR\n" +
-	"attributes\x12A\n" +
-	"\abaggage\x18\x02 \x03(\v2'.dogma.protobuf.Extensions.BaggageEntryR\abaggage\x1a=\n" +
-	"\x0fAttributesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a:\n" +
-	"\fBaggageEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xea\x01\n" +
+	"\x04data\x18\x03 \x01(\fR\x04data\"\x94\x02\n" +
 	"\x06Header\x127\n" +
 	"\fcausation_id\x18\x01 \x01(\v2\x14.dogma.protobuf.UUIDR\vcausationId\x12;\n" +
 	"\x0ecorrelation_id\x18\x02 \x01(\v2\x14.dogma.protobuf.UUIDR\rcorrelationId\x12.\n" +
-	"\x06source\x18\x03 \x01(\v2\x16.dogma.protobuf.SourceR\x06source\x12:\n" +
+	"\x06source\x18\x03 \x01(\v2\x16.dogma.protobuf.SourceR\x06source\x124\n" +
 	"\n" +
-	"extensions\x18\x04 \x01(\v2\x1a.dogma.protobuf.ExtensionsR\n" +
-	"extensions\"\xcf\x02\n" +
+	"extensions\x18\x04 \x03(\v2\x14.google.protobuf.AnyR\n" +
+	"extensions\x12.\n" +
+	"\abaggage\x18\x05 \x03(\v2\x14.google.protobuf.AnyR\abaggage\"\xf9\x02\n" +
 	"\x04Body\x123\n" +
 	"\n" +
 	"message_id\x18\x01 \x01(\v2\x14.dogma.protobuf.UUIDR\tmessageId\x12'\n" +
@@ -576,10 +529,11 @@ const file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawD
 	"\n" +
 	"created_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12?\n" +
 	"\rscheduled_for\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\fscheduledFor\x121\n" +
-	"\amessage\x18\x05 \x01(\v2\x17.dogma.protobuf.MessageR\amessage\x12:\n" +
+	"\amessage\x18\x05 \x01(\v2\x17.dogma.protobuf.MessageR\amessage\x124\n" +
 	"\n" +
-	"extensions\x18\x06 \x01(\v2\x1a.dogma.protobuf.ExtensionsR\n" +
-	"extensionsB3Z1github.com/dogmatiq/enginekit/protobuf/envelopepbb\x06proto3"
+	"extensions\x18\x06 \x03(\v2\x14.google.protobuf.AnyR\n" +
+	"extensions\x12.\n" +
+	"\abaggage\x18\a \x03(\v2\x14.google.protobuf.AnyR\abaggageB3Z1github.com/dogmatiq/enginekit/protobuf/envelopepbb\x06proto3"
 
 var (
 	file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescOnce sync.Once
@@ -593,41 +547,39 @@ func file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDe
 	return file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDescData
 }
 
-var file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_goTypes = []any{
 	(*Envelope)(nil),              // 0: dogma.protobuf.Envelope
 	(*MultiEnvelope)(nil),         // 1: dogma.protobuf.MultiEnvelope
 	(*Source)(nil),                // 2: dogma.protobuf.Source
 	(*Message)(nil),               // 3: dogma.protobuf.Message
-	(*Extensions)(nil),            // 4: dogma.protobuf.Extensions
-	(*Header)(nil),                // 5: dogma.protobuf.Header
-	(*Body)(nil),                  // 6: dogma.protobuf.Body
-	nil,                           // 7: dogma.protobuf.Extensions.AttributesEntry
-	nil,                           // 8: dogma.protobuf.Extensions.BaggageEntry
-	(*identitypb.Identity)(nil),   // 9: dogma.protobuf.Identity
-	(*uuidpb.UUID)(nil),           // 10: dogma.protobuf.UUID
-	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
+	(*Header)(nil),                // 4: dogma.protobuf.Header
+	(*Body)(nil),                  // 5: dogma.protobuf.Body
+	(*identitypb.Identity)(nil),   // 6: dogma.protobuf.Identity
+	(*uuidpb.UUID)(nil),           // 7: dogma.protobuf.UUID
+	(*anypb.Any)(nil),             // 8: google.protobuf.Any
+	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
 }
 var file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_depIdxs = []int32{
-	5,  // 0: dogma.protobuf.Envelope.header:type_name -> dogma.protobuf.Header
-	6,  // 1: dogma.protobuf.Envelope.body:type_name -> dogma.protobuf.Body
-	5,  // 2: dogma.protobuf.MultiEnvelope.header:type_name -> dogma.protobuf.Header
-	6,  // 3: dogma.protobuf.MultiEnvelope.bodies:type_name -> dogma.protobuf.Body
-	9,  // 4: dogma.protobuf.Source.site:type_name -> dogma.protobuf.Identity
-	9,  // 5: dogma.protobuf.Source.application:type_name -> dogma.protobuf.Identity
-	9,  // 6: dogma.protobuf.Source.handler:type_name -> dogma.protobuf.Identity
-	10, // 7: dogma.protobuf.Message.type_id:type_name -> dogma.protobuf.UUID
-	7,  // 8: dogma.protobuf.Extensions.attributes:type_name -> dogma.protobuf.Extensions.AttributesEntry
-	8,  // 9: dogma.protobuf.Extensions.baggage:type_name -> dogma.protobuf.Extensions.BaggageEntry
-	10, // 10: dogma.protobuf.Header.causation_id:type_name -> dogma.protobuf.UUID
-	10, // 11: dogma.protobuf.Header.correlation_id:type_name -> dogma.protobuf.UUID
-	2,  // 12: dogma.protobuf.Header.source:type_name -> dogma.protobuf.Source
-	4,  // 13: dogma.protobuf.Header.extensions:type_name -> dogma.protobuf.Extensions
-	10, // 14: dogma.protobuf.Body.message_id:type_name -> dogma.protobuf.UUID
-	11, // 15: dogma.protobuf.Body.created_at:type_name -> google.protobuf.Timestamp
-	11, // 16: dogma.protobuf.Body.scheduled_for:type_name -> google.protobuf.Timestamp
-	3,  // 17: dogma.protobuf.Body.message:type_name -> dogma.protobuf.Message
-	4,  // 18: dogma.protobuf.Body.extensions:type_name -> dogma.protobuf.Extensions
+	4,  // 0: dogma.protobuf.Envelope.header:type_name -> dogma.protobuf.Header
+	5,  // 1: dogma.protobuf.Envelope.body:type_name -> dogma.protobuf.Body
+	4,  // 2: dogma.protobuf.MultiEnvelope.header:type_name -> dogma.protobuf.Header
+	5,  // 3: dogma.protobuf.MultiEnvelope.bodies:type_name -> dogma.protobuf.Body
+	6,  // 4: dogma.protobuf.Source.site:type_name -> dogma.protobuf.Identity
+	6,  // 5: dogma.protobuf.Source.application:type_name -> dogma.protobuf.Identity
+	6,  // 6: dogma.protobuf.Source.handler:type_name -> dogma.protobuf.Identity
+	7,  // 7: dogma.protobuf.Message.type_id:type_name -> dogma.protobuf.UUID
+	7,  // 8: dogma.protobuf.Header.causation_id:type_name -> dogma.protobuf.UUID
+	7,  // 9: dogma.protobuf.Header.correlation_id:type_name -> dogma.protobuf.UUID
+	2,  // 10: dogma.protobuf.Header.source:type_name -> dogma.protobuf.Source
+	8,  // 11: dogma.protobuf.Header.extensions:type_name -> google.protobuf.Any
+	8,  // 12: dogma.protobuf.Header.baggage:type_name -> google.protobuf.Any
+	7,  // 13: dogma.protobuf.Body.message_id:type_name -> dogma.protobuf.UUID
+	9,  // 14: dogma.protobuf.Body.created_at:type_name -> google.protobuf.Timestamp
+	9,  // 15: dogma.protobuf.Body.scheduled_for:type_name -> google.protobuf.Timestamp
+	3,  // 16: dogma.protobuf.Body.message:type_name -> dogma.protobuf.Message
+	8,  // 17: dogma.protobuf.Body.extensions:type_name -> google.protobuf.Any
+	8,  // 18: dogma.protobuf.Body.baggage:type_name -> google.protobuf.Any
 	19, // [19:19] is the sub-list for method output_type
 	19, // [19:19] is the sub-list for method input_type
 	19, // [19:19] is the sub-list for extension type_name
@@ -646,7 +598,7 @@ func file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_init(
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDesc), len(file_github_com_dogmatiq_enginekit_protobuf_envelopepb_envelope_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protobuf/envelopepb/envelope.proto
+++ b/protobuf/envelopepb/envelope.proto
@@ -4,6 +4,7 @@ package dogma.protobuf;
 option go_package = "github.com/dogmatiq/enginekit/protobuf/envelopepb";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/any.proto";
 import "github.com/dogmatiq/enginekit/protobuf/identitypb/identity.proto";
 import "github.com/dogmatiq/enginekit/protobuf/uuidpb/uuid.proto";
 
@@ -64,21 +65,6 @@ message Message {
   bytes data = 3;
 }
 
-// Extensions is a container for arbitrary key/value pairs associated with a
-// message and/or its causal chain.
-//
-// Keys beginning with "_" are reserved for use by the enginekit module. All
-// other keys SHOULD use reverse-domain notation, e.g. "com.example.some-key".
-message Extensions {
-  // Attributes is a set of arbitrary key/value pairs that provide additional
-  // information about the message.
-  map<string, string> attributes = 1;
-
-  // Baggage is a set of arbitrary key/value pairs that are propagated through
-  // the entire causal chain of messages.
-  map<string, string> baggage = 2;
-}
-
 message Header {
   // CausationId is the (optional) ID of the message that was the direct cause
   // of the messages.
@@ -98,11 +84,17 @@ message Header {
   // Source identifies the origin of the messages.
   Source source = 3;
 
-  // Extensions is a container for arbitrary key/value pairs associated with
-  // the messages, their causal chain, or the envelope itself.
-  Extensions extensions = 4;
+  // Extensions is a set of extension values associated with the messages,
+  // their causal chain, or the envelope itself.
+  repeated google.protobuf.Any extensions = 4;
+
+  // Baggage is a set of extension values that are propagated through the
+  // entire causal chain of messages.
+  repeated google.protobuf.Any baggage = 5;
 }
 
+// Body contains the metadata and encoded form of a single message in an
+// [Envelope] or [MultiEnvelope].
 message Body {
   // MessageId is a unique identifier for the message in this envelope.
   UUID message_id = 1;
@@ -127,10 +119,16 @@ message Body {
   // Message is the encoded representation of the [dogma.Message].
   Message message = 5;
 
-  // Extensions is a container for arbitrary key/value pairs associated with
-  // this message and/or its causal chain.
+  // Extensions is a set of extension values associated with this message.
   //
-  // Any keys present in the [Header.Extensions] field are overridden by keys
-  // in this field.
-  Extensions extensions = 6;
+  // Any values in [Header.Extensions] are overridden by values in this field
+  // that have the same type URL.
+  repeated google.protobuf.Any extensions = 6;
+
+  // Baggage is a set of extension values associated with this message and/or
+  // its causal chain.
+  //
+  // Any values in [Header.Baggage] are overridden by values in this field
+  // that have the same type URL.
+  repeated google.protobuf.Any baggage = 7;
 }

--- a/protobuf/envelopepb/envelope_primo.pb.go
+++ b/protobuf/envelopepb/envelope_primo.pb.go
@@ -10,6 +10,7 @@ import (
 	identitypb "github.com/dogmatiq/enginekit/protobuf/identitypb"
 	uuidpb "github.com/dogmatiq/enginekit/protobuf/uuidpb"
 	proto "google.golang.org/protobuf/proto"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -220,51 +221,6 @@ func (b *MessageBuilder) WithData(v []byte) *MessageBuilder {
 	return b
 }
 
-type ExtensionsBuilder struct {
-	prototype Extensions
-}
-
-// NewExtensionsBuilder returns a builder that constructs [Extensions] messages.
-func NewExtensionsBuilder() *ExtensionsBuilder {
-	return &ExtensionsBuilder{}
-}
-
-// From configures the builder to use x as the prototype for new messages,
-// then returns b.
-//
-// It performs a shallow copy of x, such that any changes made via the builder
-// do not modify x. It does not make a copy of the field values themselves.
-func (b *ExtensionsBuilder) From(x *Extensions) *ExtensionsBuilder {
-	b.prototype.Attributes = x.Attributes
-	b.prototype.Baggage = x.Baggage
-	return b
-}
-
-// Build returns a new [Extensions] containing the values configured via the builder.
-//
-// Each call returns a new message, such that future changes to the builder do
-// not modify previously constructed messages.
-func (b *ExtensionsBuilder) Build() *Extensions {
-	return &Extensions{
-		Attributes: b.prototype.Attributes,
-		Baggage:    b.prototype.Baggage,
-	}
-}
-
-// WithAttributes configures the builder to set the Attributes field to v,
-// then returns b.
-func (b *ExtensionsBuilder) WithAttributes(v map[string]string) *ExtensionsBuilder {
-	b.prototype.Attributes = v
-	return b
-}
-
-// WithBaggage configures the builder to set the Baggage field to v,
-// then returns b.
-func (b *ExtensionsBuilder) WithBaggage(v map[string]string) *ExtensionsBuilder {
-	b.prototype.Baggage = v
-	return b
-}
-
 type HeaderBuilder struct {
 	prototype Header
 }
@@ -284,6 +240,7 @@ func (b *HeaderBuilder) From(x *Header) *HeaderBuilder {
 	b.prototype.CorrelationId = x.CorrelationId
 	b.prototype.Source = x.Source
 	b.prototype.Extensions = x.Extensions
+	b.prototype.Baggage = x.Baggage
 	return b
 }
 
@@ -297,6 +254,7 @@ func (b *HeaderBuilder) Build() *Header {
 		CorrelationId: b.prototype.CorrelationId,
 		Source:        b.prototype.Source,
 		Extensions:    b.prototype.Extensions,
+		Baggage:       b.prototype.Baggage,
 	}
 }
 
@@ -323,8 +281,15 @@ func (b *HeaderBuilder) WithSource(v *Source) *HeaderBuilder {
 
 // WithExtensions configures the builder to set the Extensions field to v,
 // then returns b.
-func (b *HeaderBuilder) WithExtensions(v *Extensions) *HeaderBuilder {
+func (b *HeaderBuilder) WithExtensions(v []*anypb.Any) *HeaderBuilder {
 	b.prototype.Extensions = v
+	return b
+}
+
+// WithBaggage configures the builder to set the Baggage field to v,
+// then returns b.
+func (b *HeaderBuilder) WithBaggage(v []*anypb.Any) *HeaderBuilder {
+	b.prototype.Baggage = v
 	return b
 }
 
@@ -349,6 +314,7 @@ func (b *BodyBuilder) From(x *Body) *BodyBuilder {
 	b.prototype.ScheduledFor = x.ScheduledFor
 	b.prototype.Message = x.Message
 	b.prototype.Extensions = x.Extensions
+	b.prototype.Baggage = x.Baggage
 	return b
 }
 
@@ -364,6 +330,7 @@ func (b *BodyBuilder) Build() *Body {
 		ScheduledFor:   b.prototype.ScheduledFor,
 		Message:        b.prototype.Message,
 		Extensions:     b.prototype.Extensions,
+		Baggage:        b.prototype.Baggage,
 	}
 }
 
@@ -404,8 +371,15 @@ func (b *BodyBuilder) WithMessage(v *Message) *BodyBuilder {
 
 // WithExtensions configures the builder to set the Extensions field to v,
 // then returns b.
-func (b *BodyBuilder) WithExtensions(v *Extensions) *BodyBuilder {
+func (b *BodyBuilder) WithExtensions(v []*anypb.Any) *BodyBuilder {
 	b.prototype.Extensions = v
+	return b
+}
+
+// WithBaggage configures the builder to set the Baggage field to v,
+// then returns b.
+func (b *BodyBuilder) WithBaggage(v []*anypb.Any) *BodyBuilder {
+	b.prototype.Baggage = v
 	return b
 }
 
@@ -470,22 +444,6 @@ func (x *Message) MarshalBinary() ([]byte, error) {
 //
 // It allows [*Message] to implement [encoding.BinaryUnmarshaler].
 func (x *Message) UnmarshalBinary(data []byte) error {
-	return proto.Unmarshal(data, x)
-}
-
-// MarshalBinary returns the binary representation of the message, equivalent to
-// calling proto.Marshal(x).
-//
-// It allows [*Extensions] to implement [encoding.BinaryMarshaler].
-func (x *Extensions) MarshalBinary() ([]byte, error) {
-	return proto.Marshal(x)
-}
-
-// UnmarshalBinary populates x from its binary representation, equivalent to
-// calling proto.Unmarshal(data, x).
-//
-// It allows [*Extensions] to implement [encoding.BinaryUnmarshaler].
-func (x *Extensions) UnmarshalBinary(data []byte) error {
 	return proto.Unmarshal(data, x)
 }
 
@@ -576,16 +534,6 @@ func (x *Message) SetData(v []byte) {
 	x.Data = v
 }
 
-// SetAttributes sets the x.Attributes field to v, then returns x.
-func (x *Extensions) SetAttributes(v map[string]string) {
-	x.Attributes = v
-}
-
-// SetBaggage sets the x.Baggage field to v, then returns x.
-func (x *Extensions) SetBaggage(v map[string]string) {
-	x.Baggage = v
-}
-
 // SetCausationId sets the x.CausationId field to v, then returns x.
 func (x *Header) SetCausationId(v *uuidpb.UUID) {
 	x.CausationId = v
@@ -602,8 +550,13 @@ func (x *Header) SetSource(v *Source) {
 }
 
 // SetExtensions sets the x.Extensions field to v, then returns x.
-func (x *Header) SetExtensions(v *Extensions) {
+func (x *Header) SetExtensions(v []*anypb.Any) {
 	x.Extensions = v
+}
+
+// SetBaggage sets the x.Baggage field to v, then returns x.
+func (x *Header) SetBaggage(v []*anypb.Any) {
+	x.Baggage = v
 }
 
 // SetMessageId sets the x.MessageId field to v, then returns x.
@@ -632,6 +585,11 @@ func (x *Body) SetMessage(v *Message) {
 }
 
 // SetExtensions sets the x.Extensions field to v, then returns x.
-func (x *Body) SetExtensions(v *Extensions) {
+func (x *Body) SetExtensions(v []*anypb.Any) {
 	x.Extensions = v
+}
+
+// SetBaggage sets the x.Baggage field to v, then returns x.
+func (x *Body) SetBaggage(v []*anypb.Any) {
+	x.Baggage = v
 }

--- a/protobuf/envelopepb/envelope_test.go
+++ b/protobuf/envelopepb/envelope_test.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	. "github.com/dogmatiq/enginekit/internal/test"
 	"github.com/dogmatiq/enginekit/protobuf/envelopepb"
 	. "github.com/dogmatiq/enginekit/protobuf/envelopepb"
 	identitypb "github.com/dogmatiq/enginekit/protobuf/identitypb"
 	uuidpb "github.com/dogmatiq/enginekit/protobuf/uuidpb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -48,9 +50,9 @@ func TestEnvelope_Validate(t *testing.T) {
 				}),
 			},
 			{
-				"without attributes",
+				"without extensions",
 				newEnvelope(func(e *Envelope) {
-					e.Body.Extensions.Attributes = nil
+					e.Body.Extensions = nil
 				}),
 			},
 			{
@@ -197,6 +199,322 @@ func TestEnvelope_Validate(t *testing.T) {
 	})
 }
 
+func TestWireCompatibility(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		Desc             string
+		HeaderExtensions []*anypb.Any
+		HeaderBaggage    []*anypb.Any
+		BodyExtensions   []*anypb.Any
+		BodyBaggage      []*anypb.Any
+		WantExtensions   []*anypb.Any
+		WantBaggage      []*anypb.Any
+	}{
+		{
+			Desc: "header only",
+			HeaderExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("header-a"),
+				},
+			},
+			HeaderBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a"),
+				},
+			},
+			WantExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("header-a"),
+				},
+			},
+			WantBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a"),
+				},
+			},
+		},
+		{
+			Desc: "body only",
+			BodyExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("body-a"),
+				},
+			},
+			BodyBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("body-a"),
+				},
+			},
+			WantExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("body-a"),
+				},
+			},
+			WantBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("body-a"),
+				},
+			},
+		},
+		{
+			Desc: "split with overrides",
+			HeaderExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("header-a"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionB",
+					Value:   []byte("header-b"),
+				},
+			},
+			HeaderBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageB",
+					Value:   []byte("header-b"),
+				},
+			},
+			BodyExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionB",
+					Value:   []byte("body-b"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionC",
+					Value:   []byte("body-c"),
+				},
+			},
+			BodyBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageB",
+					Value:   []byte("body-b"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageC",
+					Value:   []byte("body-c"),
+				},
+			},
+			WantExtensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionA",
+					Value:   []byte("header-a"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionB",
+					Value:   []byte("body-b"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.ExtensionC",
+					Value:   []byte("body-c"),
+				},
+			},
+			WantBaggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageB",
+					Value:   []byte("body-b"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageC",
+					Value:   []byte("body-c"),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Desc, func(t *testing.T) {
+			t.Parallel()
+
+			env := newEnvelope(func(e *Envelope) {
+				e.Header.Extensions = c.HeaderExtensions
+				e.Header.Baggage = c.HeaderBaggage
+				e.Body.Extensions = c.BodyExtensions
+				e.Body.Baggage = c.BodyBaggage
+			})
+
+			expectEnvelopeWireCompatibleExtensions(
+				t,
+				env,
+				c.WantExtensions,
+				c.WantBaggage,
+			)
+
+			multi := &MultiEnvelope{
+				Header: env.Header,
+				Bodies: []*Body{env.Body},
+			}
+
+			expectSingleBodyMultiEnvelopeWireCompatibleExtensions(
+				t,
+				multi,
+				c.WantExtensions,
+				c.WantBaggage,
+			)
+		})
+	}
+}
+
+func expectEnvelopeWireCompatibleExtensions(
+	t *testing.T,
+	env *Envelope,
+	wantExtensions, wantBaggage []*anypb.Any,
+) {
+	t.Helper()
+
+	data, err := env.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got MultiEnvelope
+	if err := got.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
+	}
+
+	expectSingleBodyMultiEnvelopeEffectiveExtensions(
+		t,
+		&got,
+		wantExtensions,
+		wantBaggage,
+	)
+}
+
+func expectSingleBodyMultiEnvelopeWireCompatibleExtensions(
+	t *testing.T,
+	env *MultiEnvelope,
+	wantExtensions, wantBaggage []*anypb.Any,
+) {
+	t.Helper()
+
+	data, err := env.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got Envelope
+	if err := got.UnmarshalBinary(data); err != nil {
+		t.Fatal(err)
+	}
+
+	expectEffectiveExtensionsForTest(
+		t,
+		got.GetHeader().GetExtensions(),
+		got.GetBody().GetExtensions(),
+		got.GetHeader().GetBaggage(),
+		got.GetBody().GetBaggage(),
+		wantExtensions,
+		wantBaggage,
+	)
+}
+
+func expectSingleBodyMultiEnvelopeEffectiveExtensions(
+	t *testing.T,
+	env *MultiEnvelope,
+	wantExtensions, wantBaggage []*anypb.Any,
+) {
+	t.Helper()
+
+	bodies := env.GetBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("unexpected body count: got %d, want 1", len(bodies))
+	}
+
+	expectEffectiveExtensionsForTest(
+		t,
+		env.GetHeader().GetExtensions(),
+		bodies[0].GetExtensions(),
+		env.GetHeader().GetBaggage(),
+		bodies[0].GetBaggage(),
+		wantExtensions,
+		wantBaggage,
+	)
+}
+
+func expectEffectiveExtensionsForTest(
+	t *testing.T,
+	headerExtensions,
+	bodyExtensions,
+	headerBaggage,
+	bodyBaggage,
+	wantExtensions,
+	wantBaggage []*anypb.Any,
+) {
+	t.Helper()
+
+	Expect(
+		t,
+		"unexpected effective extensions",
+		mergedAnyValuesByTypeURLForTest(
+			headerExtensions,
+			bodyExtensions,
+		),
+		wantExtensions,
+	)
+
+	Expect(
+		t,
+		"unexpected effective baggage",
+		mergedAnyValuesByTypeURLForTest(
+			headerBaggage,
+			bodyBaggage,
+		),
+		wantBaggage,
+	)
+}
+
+func mergedAnyValuesByTypeURLForTest(header, body []*anypb.Any) []*anypb.Any {
+	if len(header) == 0 {
+		return body
+	}
+
+	if len(body) == 0 {
+		return header
+	}
+
+	values := make([]*anypb.Any, 0, len(header)+len(body))
+
+	for _, v := range header {
+		if containsAnyValueWithTypeURLForTest(body, v.GetTypeUrl()) {
+			continue
+		}
+
+		values = append(values, v)
+	}
+
+	for _, v := range body {
+		values = append(values, v)
+	}
+
+	return values
+}
+
+func containsAnyValueWithTypeURLForTest(values []*anypb.Any, typeURL string) bool {
+	for _, v := range values {
+		if v.GetTypeUrl() == typeURL {
+			return true
+		}
+	}
+
+	return false
+}
+
 func newEnvelope(modifiers ...func(*Envelope)) *envelopepb.Envelope {
 	env := &Envelope{
 		Header: &Header{
@@ -218,9 +536,17 @@ func newEnvelope(modifiers ...func(*Envelope)) *envelopepb.Envelope {
 				TypeId:      uuidpb.Generate(),
 				Data:        []byte("<data>"),
 			},
-			Extensions: &Extensions{
-				Attributes: map[string]string{"<attr-key>": "<attr-value>"},
-				Baggage:    map[string]string{"<baggage-key": "<baggage-value>"},
+			Extensions: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.envelope.v1.Extension",
+					Value:   []byte("<extension-value>"),
+				},
+			},
+			Baggage: []*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.envelope.v1.Baggage",
+					Value:   []byte("<baggage-value>"),
+				},
 			},
 		},
 	}

--- a/protobuf/envelopepb/envelope_test.go
+++ b/protobuf/envelopepb/envelope_test.go
@@ -56,6 +56,22 @@ func TestEnvelope_Validate(t *testing.T) {
 				}),
 			},
 			{
+				"with empty extension payload",
+				newEnvelope(func(e *Envelope) {
+					e.Body.Extensions = []*anypb.Any{{
+						TypeUrl: "type.googleapis.com/example.Extension",
+					}}
+				}),
+			},
+			{
+				"with empty baggage payload",
+				newEnvelope(func(e *Envelope) {
+					e.Body.Baggage = []*anypb.Any{{
+						TypeUrl: "type.googleapis.com/example.Baggage",
+					}}
+				}),
+			},
+			{
 				"without data",
 				newEnvelope(func(e *Envelope) {
 					e.Body.Message.Data = nil
@@ -167,6 +183,34 @@ func TestEnvelope_Validate(t *testing.T) {
 					e.Body.Message.Description = ""
 				}),
 				"invalid body: invalid message: invalid description: must not be empty",
+			},
+			{
+				"empty header extension",
+				newEnvelope(func(e *Envelope) {
+					e.Header.Extensions = []*anypb.Any{{}}
+				}),
+				"invalid header: invalid extensions at index 0: type URL must not be empty",
+			},
+			{
+				"empty header baggage",
+				newEnvelope(func(e *Envelope) {
+					e.Header.Baggage = []*anypb.Any{nil}
+				}),
+				"invalid header: invalid baggage at index 0: type URL must not be empty",
+			},
+			{
+				"empty body extension",
+				newEnvelope(func(e *Envelope) {
+					e.Body.Extensions = []*anypb.Any{{}}
+				}),
+				"invalid body: invalid extensions at index 0: type URL must not be empty",
+			},
+			{
+				"empty body baggage",
+				newEnvelope(func(e *Envelope) {
+					e.Body.Baggage = []*anypb.Any{{}}
+				}),
+				"invalid body: invalid baggage at index 0: type URL must not be empty",
 			},
 			{
 				"without type ID",

--- a/protobuf/envelopepb/extensions.go
+++ b/protobuf/envelopepb/extensions.go
@@ -1,0 +1,45 @@
+package envelopepb
+
+import (
+	anypb "google.golang.org/protobuf/types/known/anypb"
+)
+
+// flattenAnyValues merges two slices of [*anypb.Any] values from a [Header] and
+// [Body] into a single slice.
+//
+// Later values override earlier values with the same type URL, so body values
+// override header values and the last repeated value in either location wins.
+func flattenAnyValues(header, body []*anypb.Any) []*anypb.Any {
+	total := len(header) + len(body)
+	if total == 0 {
+		return nil
+	}
+
+	result := make([]*anypb.Any, total)
+	start := total
+
+	isSeen := func(v *anypb.Any) bool {
+		for _, x := range result[start:] {
+			if x.GetTypeUrl() == v.GetTypeUrl() {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	appendLastWins := func(values []*anypb.Any) {
+		for idx := len(values) - 1; idx >= 0; idx-- {
+			v := values[idx]
+			if !isSeen(v) {
+				start--
+				result[start] = v
+			}
+		}
+	}
+
+	appendLastWins(body)
+	appendLastWins(header)
+
+	return result[start:]
+}

--- a/protobuf/envelopepb/multipacker.go
+++ b/protobuf/envelopepb/multipacker.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 
 	"github.com/dogmatiq/dogma"
+	"github.com/dogmatiq/enginekit/protobuf/identitypb"
 	"github.com/dogmatiq/enginekit/protobuf/uuidpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// A MultiPacker puts messages into a [MultiEnvelope].
-type MultiPacker struct {
+// An EffectPacker packs messages produced while handling a specific causal
+// message into a [MultiEnvelope].
+type EffectPacker struct {
 	generateID func() *uuidpb.UUID
 	now        func() *timestamppb.Timestamp
 	header     *Header
@@ -17,14 +19,22 @@ type MultiPacker struct {
 	sealed     bool
 }
 
-// CausedBy returns a [MultiPacker] that packs messages that share env as their
-// cause into a shared [MultiEnvelope].
-func (p *Packer) CausedBy(env *Envelope, options ...SourcePackOption) *MultiPacker {
-	if env == nil {
+// PackEffects returns an [EffectPacker] that packs messages produced by h while
+// handling cause.
+func (p *Packer) PackEffects(
+	cause *Envelope,
+	h *identitypb.Identity,
+	options ...PackEffectsOption,
+) *EffectPacker {
+	if h == nil {
+		panic("handler must not be nil")
+	}
+
+	if cause == nil {
 		panic("cause must not be nil")
 	}
 
-	if err := env.Validate(); err != nil {
+	if err := cause.Validate(); err != nil {
 		panic(fmt.Errorf("invalid cause envelope: %w", err))
 	}
 
@@ -42,31 +52,55 @@ func (p *Packer) CausedBy(env *Envelope, options ...SourcePackOption) *MultiPack
 	}
 
 	header := &Header{
-		CausationId:   env.Body.MessageId,
-		CorrelationId: env.Header.CorrelationId,
+		CausationId:   cause.Body.MessageId,
+		CorrelationId: cause.Header.CorrelationId,
 		Source: &Source{
 			Site:        p.Site,
 			Application: p.Application,
+			Handler:     h,
 		},
+		Baggage: flattenAnyValues(
+			cause.GetHeader().GetBaggage(),
+			cause.GetBody().GetBaggage(),
+		),
 	}
 
 	for _, opt := range options {
-		opt.applyToSource(header.Source)
+		opt.applyPackEffectsOption(header)
 	}
 
 	if err := header.validate(); err != nil {
 		panic(fmt.Errorf("invalid header: %w", err))
 	}
 
-	return &MultiPacker{
+	return &EffectPacker{
 		generateID: generateID,
 		now:        now,
 		header:     header,
 	}
 }
 
-// Pack appends m to the multi-envelope under construction.
-func (p *MultiPacker) Pack(m dogma.Message, options ...BodyPackOption) {
+// PackCommand appends m to the multi-envelope under construction.
+func (p *EffectPacker) PackCommand(m dogma.Command, options ...PackEffectCommandOption) {
+	packEffectBody(p, m, PackEffectCommandOption.applyPackEffectCommandOption, options...)
+}
+
+// PackEvent appends m to the multi-envelope under construction.
+func (p *EffectPacker) PackEvent(m dogma.Event, options ...PackEffectEventOption) {
+	packEffectBody(p, m, PackEffectEventOption.applyPackEffectEventOption, options...)
+}
+
+// PackTimeout appends m to the multi-envelope under construction.
+func (p *EffectPacker) PackTimeout(m dogma.Timeout, options ...PackEffectTimeoutOption) {
+	packEffectBody(p, m, PackEffectTimeoutOption.applyPackEffectTimeoutOption, options...)
+}
+
+func packEffectBody[T any](
+	p *EffectPacker,
+	m dogma.Message,
+	apply func(T, *Body),
+	options ...T,
+) {
 	p.mustNotBeSealed()
 
 	mt, ok := dogma.RegisteredMessageTypeOf(m)
@@ -96,7 +130,7 @@ func (p *MultiPacker) Pack(m dogma.Message, options ...BodyPackOption) {
 	}
 
 	for _, opt := range options {
-		opt.applyToBody(body)
+		apply(opt, body)
 	}
 
 	if body.CreatedAt == nil {
@@ -112,7 +146,7 @@ func (p *MultiPacker) Pack(m dogma.Message, options ...BodyPackOption) {
 
 // Seal returns a [MultiEnvelope] containing all packed messages, or false if no
 // messages were packed.
-func (p *MultiPacker) Seal() (*MultiEnvelope, bool) {
+func (p *EffectPacker) Seal() (*MultiEnvelope, bool) {
 	p.mustNotBeSealed()
 	p.sealed = true
 
@@ -126,7 +160,7 @@ func (p *MultiPacker) Seal() (*MultiEnvelope, bool) {
 	}, true
 }
 
-func (p *MultiPacker) mustNotBeSealed() {
+func (p *EffectPacker) mustNotBeSealed() {
 	if p.sealed {
 		panic("already sealed")
 	}

--- a/protobuf/envelopepb/multipacker_test.go
+++ b/protobuf/envelopepb/multipacker_test.go
@@ -9,10 +9,31 @@ import (
 	. "github.com/dogmatiq/enginekit/protobuf/envelopepb"
 	"github.com/dogmatiq/enginekit/protobuf/identitypb"
 	"github.com/dogmatiq/enginekit/protobuf/uuidpb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestPacker_CausedBy(t *testing.T) {
+	t.Run("it panics if the handler is nil", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		cause := packer.PackCommand(CommandA1)
+
+		ExpectPanic(
+			t,
+			"handler must not be nil",
+			func() {
+				packer.PackEffects(cause, nil)
+			},
+		)
+	})
+
 	t.Run("it panics if the cause is nil", func(t *testing.T) {
 		packer := &Packer{
 			Application: &identitypb.Identity{
@@ -21,11 +42,16 @@ func TestPacker_CausedBy(t *testing.T) {
 			},
 		}
 
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
 		ExpectPanic(
 			t,
 			"cause must not be nil",
 			func() {
-				packer.CausedBy(nil)
+				packer.PackEffects(nil, handler)
 			},
 		)
 	})
@@ -38,27 +64,36 @@ func TestPacker_CausedBy(t *testing.T) {
 			},
 		}
 
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
 		ExpectPanic(
 			t,
 			"invalid cause envelope: invalid header: must not be nil",
 			func() {
-				packer.CausedBy(&Envelope{})
+				packer.PackEffects(&Envelope{}, handler)
 			},
 		)
 	})
 
 	t.Run("it snapshots the packer state", func(t *testing.T) {
 		causeID := uuidpb.Generate()
-		childID := uuidpb.Generate()
+		packedID := uuidpb.Generate()
 		now := time.Now()
 
-		ids := []*uuidpb.UUID{causeID, childID}
+		ids := []*uuidpb.UUID{causeID, packedID}
 		site := &identitypb.Identity{
 			Name: "site",
 			Key:  uuidpb.Generate(),
 		}
 		application := &identitypb.Identity{
 			Name: "app",
+			Key:  uuidpb.Generate(),
+		}
+		handler := &identitypb.Identity{
+			Name: "handler",
 			Key:  uuidpb.Generate(),
 		}
 
@@ -75,8 +110,8 @@ func TestPacker_CausedBy(t *testing.T) {
 			},
 		}
 
-		cause := packer.Pack(CommandA1)
-		mp := packer.CausedBy(cause)
+		cause := packer.PackCommand(CommandA1)
+		ep := packer.PackEffects(cause, handler)
 
 		packer.Site = &identitypb.Identity{Name: "other-site", Key: uuidpb.Generate()}
 		packer.Application = &identitypb.Identity{Name: "other-app", Key: uuidpb.Generate()}
@@ -87,9 +122,9 @@ func TestPacker_CausedBy(t *testing.T) {
 			return now.Add(24 * time.Hour)
 		}
 
-		mp.Pack(CommandA2)
+		ep.PackCommand(CommandA2)
 
-		got, ok := mp.Seal()
+		got, ok := ep.Seal()
 		if !ok {
 			t.Fatal("expected a multi-envelope")
 		}
@@ -106,8 +141,12 @@ func TestPacker_CausedBy(t *testing.T) {
 			t.Fatalf("unexpected application: got %s, want %s", got.Header.Source.Application, application)
 		}
 
-		if !got.Bodies[0].MessageId.Equal(childID) {
-			t.Fatalf("unexpected child message ID: got %s, want %s", got.Bodies[0].MessageId, childID)
+		if !got.Header.Source.Handler.Equal(handler) {
+			t.Fatalf("unexpected handler: got %s, want %s", got.Header.Source.Handler, handler)
+		}
+
+		if !got.Bodies[0].MessageId.Equal(packedID) {
+			t.Fatalf("unexpected packed message ID: got %s, want %s", got.Bodies[0].MessageId, packedID)
 		}
 
 		if !got.Bodies[0].CreatedAt.AsTime().Equal(now) {
@@ -115,7 +154,7 @@ func TestPacker_CausedBy(t *testing.T) {
 		}
 	})
 
-	t.Run("it applies source options", func(t *testing.T) {
+	t.Run("it applies effect packer options to the shared source", func(t *testing.T) {
 		packer := &Packer{
 			Application: &identitypb.Identity{
 				Name: "app",
@@ -132,21 +171,21 @@ func TestPacker_CausedBy(t *testing.T) {
 			Key:  uuidpb.Generate(),
 		}
 
-		cause := packer.Pack(CommandA1)
+		cause := packer.PackCommand(CommandA1)
 
-		left := packer.CausedBy(
+		left := packer.PackEffects(
 			cause,
-			WithHandler(handlerA),
+			handlerA,
 			WithInstanceID("instance-a"),
 		)
-		left.Pack(TimeoutA1, WithScheduledFor(time.Now().Add(time.Hour)))
+		left.PackTimeout(TimeoutA1, WithScheduledFor(time.Now().Add(time.Hour)))
 
-		right := packer.CausedBy(
+		right := packer.PackEffects(
 			cause,
-			WithHandler(handlerB),
+			handlerB,
 			WithInstanceID("instance-b"),
 		)
-		right.Pack(TimeoutA2, WithScheduledFor(time.Now().Add(2*time.Hour)))
+		right.PackTimeout(TimeoutA2, WithScheduledFor(time.Now().Add(2*time.Hour)))
 
 		leftEnv, ok := left.Seal()
 		if !ok {
@@ -166,6 +205,11 @@ func TestPacker_CausedBy(t *testing.T) {
 			t.Fatalf("unexpected left instance ID: got %q, want %q", leftEnv.Header.Source.InstanceId, "instance-a")
 		}
 
+		leftScheduledFor := leftEnv.Bodies[0].ScheduledFor.AsTime()
+		if leftScheduledFor.IsZero() {
+			t.Fatal("expected left scheduled-for time")
+		}
+
 		if !rightEnv.Header.Source.Handler.Equal(handlerB) {
 			t.Fatalf("unexpected right handler: got %s, want %s", rightEnv.Header.Source.Handler, handlerB)
 		}
@@ -173,10 +217,237 @@ func TestPacker_CausedBy(t *testing.T) {
 		if rightEnv.Header.Source.InstanceId != "instance-b" {
 			t.Fatalf("unexpected right instance ID: got %q, want %q", rightEnv.Header.Source.InstanceId, "instance-b")
 		}
+
+		rightScheduledFor := rightEnv.Bodies[0].ScheduledFor.AsTime()
+		if rightScheduledFor.IsZero() {
+			t.Fatal("expected right scheduled-for time")
+		}
+	})
+
+	t.Run("it applies extension and baggage options to the header", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		extension := wrapperspb.String("extension")
+		wantExtension, err := anypb.New(extension)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		baggage := wrapperspb.String("baggage")
+		wantBaggage, err := anypb.New(baggage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		ep := packer.PackEffects(
+			cause,
+			handler,
+			WithExtension(extension),
+			WithBaggage(baggage),
+		)
+		ep.PackCommand(CommandA2)
+
+		got, ok := ep.Seal()
+		if !ok {
+			t.Fatal("expected a multi-envelope")
+		}
+
+		Expect(
+			t,
+			"unexpected header extensions",
+			got.Header.Extensions,
+			[]*anypb.Any{wantExtension},
+		)
+
+		Expect(
+			t,
+			"unexpected header baggage",
+			got.Header.Baggage,
+			[]*anypb.Any{wantBaggage},
+		)
+
+		if got.Bodies[0].Extensions != nil || got.Bodies[0].Baggage != nil {
+			t.Fatalf(
+				"unexpected body extension state: got extensions %#v, baggage %#v, want nil",
+				got.Bodies[0].Extensions,
+				got.Bodies[0].Baggage,
+			)
+		}
+	})
+
+	t.Run("it keeps only the last baggage value for a type URL when propagating from the cause", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		cause.Header.Baggage = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageA",
+				Value:   []byte("header-a-1"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageA",
+				Value:   []byte("header-a-2"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageB",
+				Value:   []byte("header-b"),
+			},
+		}
+
+		cause.Body.Baggage = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageB",
+				Value:   []byte("body-b-1"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageB",
+				Value:   []byte("body-b-2"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageC",
+				Value:   []byte("body-c"),
+			},
+		}
+
+		ep := packer.PackEffects(cause, handler)
+		ep.PackCommand(CommandA2)
+
+		got, ok := ep.Seal()
+		if !ok {
+			t.Fatal("expected a multi-envelope")
+		}
+
+		Expect(
+			t,
+			"unexpected propagated baggage",
+			got.Header.Baggage,
+			[]*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a-2"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageB",
+					Value:   []byte("body-b-2"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageC",
+					Value:   []byte("body-c"),
+				},
+			},
+		)
+	})
+
+	t.Run("it propagates baggage but not extensions from the cause", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		cause.Header.Extensions = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.ExtensionA",
+				Value:   []byte("header-a"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.ExtensionB",
+				Value:   []byte("header-b"),
+			},
+		}
+
+		cause.Header.Baggage = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageA",
+				Value:   []byte("header-a"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageB",
+				Value:   []byte("header-b"),
+			},
+		}
+
+		cause.Body.Extensions = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.ExtensionB",
+				Value:   []byte("body-b"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.ExtensionC",
+				Value:   []byte("body-c"),
+			},
+		}
+
+		cause.Body.Baggage = []*anypb.Any{
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageB",
+				Value:   []byte("body-b"),
+			},
+			{
+				TypeUrl: "type.googleapis.com/example.BaggageC",
+				Value:   []byte("body-c"),
+			},
+		}
+
+		ep := packer.PackEffects(cause, handler)
+		ep.PackCommand(CommandA2)
+
+		got, ok := ep.Seal()
+		if !ok {
+			t.Fatal("expected a multi-envelope")
+		}
+
+		expectSingleBodyMultiEnvelopeWireCompatibleExtensions(
+			t,
+			got,
+			nil,
+			[]*anypb.Any{
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageA",
+					Value:   []byte("header-a"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageB",
+					Value:   []byte("body-b"),
+				},
+				{
+					TypeUrl: "type.googleapis.com/example.BaggageC",
+					Value:   []byte("body-c"),
+				},
+			},
+		)
 	})
 }
 
-func TestMultiPacker_Pack(t *testing.T) {
+func TestEffectPacker_Pack(t *testing.T) {
 	t.Run("it panics if the body is invalid", func(t *testing.T) {
 		packer := &Packer{
 			Application: &identitypb.Identity{
@@ -185,20 +456,61 @@ func TestMultiPacker_Pack(t *testing.T) {
 			},
 		}
 
-		cause := packer.Pack(CommandA1)
-		mp := packer.CausedBy(cause)
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		ep := packer.PackEffects(cause, handler)
 
 		ExpectPanic(
 			t,
 			"invalid body: invalid scheduled-for time: must not be specified without a source handler and instance ID",
 			func() {
-				mp.Pack(TimeoutA1, WithScheduledFor(time.Now().Add(time.Hour)))
+				ep.PackTimeout(TimeoutA1, WithScheduledFor(time.Now().Add(time.Hour)))
 			},
+		)
+	})
+
+	t.Run("it applies baggage options to the body", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		baggage := wrapperspb.String("baggage")
+		want, err := anypb.New(baggage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		ep := packer.PackEffects(cause, handler)
+		ep.PackCommand(CommandA2, WithBaggage(baggage))
+
+		got, ok := ep.Seal()
+		if !ok {
+			t.Fatal("expected a multi-envelope")
+		}
+
+		Expect(
+			t,
+			"unexpected baggage extensions",
+			got.Bodies[0].Baggage,
+			[]*anypb.Any{want},
 		)
 	})
 }
 
-func TestMultiPacker_Seal(t *testing.T) {
+func TestEffectPacker_Seal(t *testing.T) {
 	t.Run("it returns the packed messages in insertion order", func(t *testing.T) {
 		id0 := uuidpb.Generate()
 		id1 := uuidpb.Generate()
@@ -225,13 +537,18 @@ func TestMultiPacker_Seal(t *testing.T) {
 			},
 		}
 
-		cause := packer.Pack(CommandA1)
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
 
-		mp := packer.CausedBy(cause)
-		mp.Pack(CommandA1, WithIdempotencyKey("key-a1"))
-		mp.Pack(CommandA2)
+		cause := packer.PackCommand(CommandA1)
 
-		got, ok := mp.Seal()
+		ep := packer.PackEffects(cause, handler)
+		ep.PackCommand(CommandA1)
+		ep.PackCommand(CommandA2)
+
+		got, ok := ep.Seal()
 		if !ok {
 			t.Fatal("expected a multi-envelope")
 		}
@@ -241,7 +558,7 @@ func TestMultiPacker_Seal(t *testing.T) {
 		}
 
 		if err := got.Validate(); err != nil {
-			t.Fatalf("multi-packer produced an invalid envelope: %v", err)
+			t.Fatalf("effect packer produced an invalid envelope: %v", err)
 		}
 
 		want := &MultiEnvelope{
@@ -251,13 +568,13 @@ func TestMultiPacker_Seal(t *testing.T) {
 				Source: &Source{
 					Site:        packer.Site,
 					Application: packer.Application,
+					Handler:     handler,
 				},
 			},
 			Bodies: []*Body{
 				{
-					MessageId:      id1,
-					CreatedAt:      timestamppb.New(now),
-					IdempotencyKey: "key-a1",
+					MessageId: id1,
+					CreatedAt: timestamppb.New(now),
 					Message: &Message{
 						Description: `command(stubs.TypeA:A1, valid)`,
 						TypeId:      uuidpb.MustParse(MessageTypeID[*CommandStub[TypeA]]()),
@@ -292,8 +609,13 @@ func TestMultiPacker_Seal(t *testing.T) {
 			},
 		}
 
-		cause := packer.Pack(CommandA1)
-		got, ok := packer.CausedBy(cause).Seal()
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
+		got, ok := packer.PackEffects(cause, handler).Seal()
 
 		if ok {
 			t.Fatal("expected no multi-envelope")
@@ -312,17 +634,22 @@ func TestMultiPacker_Seal(t *testing.T) {
 			},
 		}
 
-		cause := packer.Pack(CommandA1)
+		handler := &identitypb.Identity{
+			Name: "handler",
+			Key:  uuidpb.Generate(),
+		}
+
+		cause := packer.PackCommand(CommandA1)
 
 		t.Run("after empty seal", func(t *testing.T) {
-			mp := packer.CausedBy(cause)
-			_, _ = mp.Seal()
+			ep := packer.PackEffects(cause, handler)
+			_, _ = ep.Seal()
 
 			ExpectPanic(
 				t,
 				"already sealed",
 				func() {
-					mp.Pack(CommandA1)
+					ep.PackCommand(CommandA1)
 				},
 			)
 
@@ -330,21 +657,21 @@ func TestMultiPacker_Seal(t *testing.T) {
 				t,
 				"already sealed",
 				func() {
-					mp.Seal()
+					ep.Seal()
 				},
 			)
 		})
 
 		t.Run("after non-empty seal", func(t *testing.T) {
-			mp := packer.CausedBy(cause)
-			mp.Pack(CommandA1)
-			_, _ = mp.Seal()
+			ep := packer.PackEffects(cause, handler)
+			ep.PackCommand(CommandA1)
+			_, _ = ep.Seal()
 
 			ExpectPanic(
 				t,
 				"already sealed",
 				func() {
-					mp.Pack(CommandA2)
+					ep.PackCommand(CommandA2)
 				},
 			)
 
@@ -352,7 +679,7 @@ func TestMultiPacker_Seal(t *testing.T) {
 				t,
 				"already sealed",
 				func() {
-					mp.Seal()
+					ep.Seal()
 				},
 			)
 		})

--- a/protobuf/envelopepb/multipacker_test.go
+++ b/protobuf/envelopepb/multipacker_test.go
@@ -503,7 +503,7 @@ func TestEffectPacker_Pack(t *testing.T) {
 
 		Expect(
 			t,
-			"unexpected baggage extensions",
+			"unexpected baggage values",
 			got.Bodies[0].Baggage,
 			[]*anypb.Any{want},
 		)

--- a/protobuf/envelopepb/packer.go
+++ b/protobuf/envelopepb/packer.go
@@ -7,6 +7,8 @@ import (
 	"github.com/dogmatiq/dogma"
 	"github.com/dogmatiq/enginekit/protobuf/identitypb"
 	"github.com/dogmatiq/enginekit/protobuf/uuidpb"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -33,8 +35,8 @@ type Packer struct {
 	Now func() time.Time
 }
 
-// Pack returns an envelope containing the given message.
-func (p *Packer) Pack(m dogma.Message, options ...PackOption) *Envelope {
+// PackCommand returns an envelope containing the given command.
+func (p *Packer) PackCommand(m dogma.Command, options ...PackCommandOption) *Envelope {
 	mt, ok := dogma.RegisteredMessageTypeOf(m)
 	if !ok {
 		panic(fmt.Sprintf(
@@ -74,12 +76,18 @@ func (p *Packer) Pack(m dogma.Message, options ...PackOption) *Envelope {
 	}
 
 	for _, opt := range options {
-		opt.applyToEnvelope(env)
+		opt.applyPackCommandOption(env)
 	}
 
 	if env.Body.CreatedAt == nil {
 		env.Body.CreatedAt = p.now()
 	}
+
+	// For a "single envelope" we normalize extensions and baggage into the body.
+	env.Body.Extensions = flattenAnyValues(env.Header.Extensions, env.Body.Extensions)
+	env.Body.Baggage = flattenAnyValues(env.Header.Baggage, env.Body.Baggage)
+	env.Header.Extensions = nil
+	env.Header.Baggage = nil
 
 	if err := env.Validate(); err != nil {
 		panic(err)
@@ -130,104 +138,163 @@ func (p *Packer) generateID() *uuidpb.UUID {
 	return uuidpb.Generate()
 }
 
-// PackOption is an option that alters the behavior of a [Packer.Pack]
-// operation.
-type PackOption interface {
-	applyToEnvelope(*Envelope)
+// PackCommandOption is an option that modifies the behavior of
+// [Packer.PackCommand].
+type PackCommandOption interface {
+	applyPackCommandOption(*Envelope)
 }
 
-// SourcePackOption is a [PackOption] that modifies only the source
-// information in an envelope header.
-type SourcePackOption interface {
-	PackOption
-	applyToSource(*Source)
+// PackEffectsOption is an option that modifies the behavior of
+// [Packer.PackEffects].
+type PackEffectsOption interface {
+	applyPackEffectsOption(*Header)
 }
 
-// BodyPackOption is a [PackOption] that modifies only envelope bodies.
-type BodyPackOption interface {
-	PackOption
-	applyToBody(*Body)
+// PackEffectCommandOption is an option that modifies the behavior of
+// [EffectPacker.PackCommand].
+type PackEffectCommandOption interface {
+	applyPackEffectCommandOption(*Body)
 }
 
-type packOption func(*Envelope)
-
-func (opt packOption) applyToEnvelope(env *Envelope) {
-	opt(env)
+// PackEffectEventOption is an option that modifies the behavior of
+// [EffectPacker.PackEvent].
+type PackEffectEventOption interface {
+	applyPackEffectEventOption(*Body)
 }
 
-type sourcePackOption func(*Source)
-
-func (opt sourcePackOption) applyToEnvelope(env *Envelope) {
-	opt(env.Header.Source)
+// PackEffectTimeoutOption is an option that modifies the behavior of
+// [EffectPacker.PackTimeout].
+type PackEffectTimeoutOption interface {
+	applyPackEffectTimeoutOption(*Body)
 }
 
-func (opt sourcePackOption) applyToSource(source *Source) {
-	opt(source)
-}
+type (
+	packEffectsOption           func(*Header)
+	packCommandOptionFunc       func(*Body)
+	packEffectTimeoutOptionFunc func(*Body)
+	universalOption             struct {
+		applyToBodyFunc   func(*Body)
+		applyToHeaderFunc func(*Header)
+	}
+)
 
-type bodyPackOption func(*Body)
+func (o packEffectsOption) applyPackEffectsOption(header *Header)             { o(header) }
+func (o packCommandOptionFunc) applyPackCommandOption(env *Envelope)          { o(env.Body) }
+func (o packEffectTimeoutOptionFunc) applyPackEffectTimeoutOption(body *Body) { o(body) }
+func (o universalOption) applyPackCommandOption(env *Envelope)                { o.applyToBodyFunc(env.Body) }
+func (o universalOption) applyPackEffectCommandOption(body *Body)             { o.applyToBodyFunc(body) }
+func (o universalOption) applyPackEffectEventOption(body *Body)               { o.applyToBodyFunc(body) }
+func (o universalOption) applyPackEffectTimeoutOption(body *Body)             { o.applyToBodyFunc(body) }
+func (o universalOption) applyPackEffectsOption(header *Header)               { o.applyToHeaderFunc(header) }
 
-func (opt bodyPackOption) applyToEnvelope(env *Envelope) {
-	opt(env.Body)
-}
-
-func (opt bodyPackOption) applyToBody(body *Body) {
-	opt(body)
-}
-
-// WithCause sets env as the "cause" of the message being packed.
-func WithCause(env *Envelope) PackOption {
-	return packOption(
-		func(packed *Envelope) {
-			packed.Header.CausationId = env.GetBody().GetMessageId()
-			packed.Header.CorrelationId = env.GetHeader().GetCorrelationId()
-		},
-	)
-}
-
-// WithHandler sets h as the identity of the handler that is the source of the
-// message.
-func WithHandler(h *identitypb.Identity) SourcePackOption {
-	return sourcePackOption(
-		func(source *Source) {
-			source.Handler = h
-		},
-	)
-}
-
-// WithInstanceID sets the aggregate or process instance ID that is the
-// source of the message.
-func WithInstanceID(id string) SourcePackOption {
-	return sourcePackOption(
-		func(source *Source) {
-			source.InstanceId = id
-		},
-	)
-}
-
-// WithCreatedAt sets the creation time of a message.
-func WithCreatedAt(t time.Time) BodyPackOption {
-	return bodyPackOption(
+// WithIdempotencyKey sets the idempotency key of a command packed via
+// [Packer.PackCommand].
+func WithIdempotencyKey(key string) PackCommandOption {
+	return packCommandOptionFunc(
 		func(body *Body) {
-			body.CreatedAt = timestamppb.New(t)
+			body.IdempotencyKey = key
 		},
 	)
 }
 
-// WithScheduledFor sets the scheduled time of a timeout message.
-func WithScheduledFor(t time.Time) BodyPackOption {
-	return bodyPackOption(
+// WithInstanceID sets the aggregate or process instance ID that is the source
+// of messages packed via [Packer.PackEffects].
+func WithInstanceID(id string) PackEffectsOption {
+	return packEffectsOption(
+		func(header *Header) {
+			header.Source.InstanceId = id
+		},
+	)
+}
+
+// WithScheduledFor sets the scheduled time of a timeout packed via
+// [EffectPacker.PackTimeout].
+func WithScheduledFor(t time.Time) PackEffectTimeoutOption {
+	return packEffectTimeoutOptionFunc(
 		func(body *Body) {
 			body.ScheduledFor = timestamppb.New(t)
 		},
 	)
 }
 
-// WithIdempotencyKey sets the idempotency key of a command message.
-func WithIdempotencyKey(key string) BodyPackOption {
-	return bodyPackOption(
-		func(body *Body) {
-			body.IdempotencyKey = key
+// WithExtension adds x to the envelope's extensions.
+//
+// Extensions apply only to the envelope being packed; they are not inherited
+// by downstream messages in the causal chain.
+func WithExtension(x proto.Message) interface {
+	PackCommandOption
+	PackEffectsOption
+	PackEffectCommandOption
+	PackEffectEventOption
+	PackEffectTimeoutOption
+} {
+	v := marshalAsAny(x)
+
+	return universalOption{
+		applyToBodyFunc: func(body *Body) {
+			appendOrReplace(&body.Extensions, v)
 		},
-	)
+		applyToHeaderFunc: func(header *Header) {
+			appendOrReplace(&header.Extensions, v)
+		},
+	}
+}
+
+// WithBaggage adds x to the envelope's baggage.
+//
+// Baggage applies to the envelope being packed and is inherited by downstream
+// messages in the causal chain.
+func WithBaggage(x proto.Message) interface {
+	PackCommandOption
+	PackEffectsOption
+	PackEffectCommandOption
+	PackEffectEventOption
+	PackEffectTimeoutOption
+} {
+	v := marshalAsAny(x)
+
+	return universalOption{
+		applyToBodyFunc: func(body *Body) {
+			appendOrReplace(&body.Baggage, v)
+		},
+		applyToHeaderFunc: func(header *Header) {
+			appendOrReplace(&header.Baggage, v)
+		},
+	}
+}
+
+// appendOrReplace appends value to values if there is no existing value with
+// the same type URL, otherwise it replaces the existing value in place.
+func appendOrReplace(values *[]*anypb.Any, value *anypb.Any) {
+	for index, existing := range *values {
+		if existing.GetTypeUrl() == value.GetTypeUrl() {
+			(*values)[index] = value
+			return
+		}
+	}
+
+	*values = append(*values, value)
+}
+
+// marshalAsAny returns v as an [*anypb.Any], converting it if necessary. It
+// panics if x is nil or x cannot be marshaled.
+func marshalAsAny(x proto.Message) *anypb.Any {
+	if x == nil {
+		panic("extension value must not be nil")
+	}
+
+	if v, ok := x.(*anypb.Any); ok {
+		return v
+	}
+
+	v, err := anypb.New(x)
+	if err != nil {
+		panic(fmt.Sprintf(
+			"unable to marshal %T as google.protobuf.Any: %s",
+			x,
+			err,
+		))
+	}
+
+	return v
 }

--- a/protobuf/envelopepb/packer.go
+++ b/protobuf/envelopepb/packer.go
@@ -97,6 +97,7 @@ func (p *Packer) PackCommand(m dogma.Command, options ...PackCommandOption) *Env
 }
 
 // Unpack returns the message contained within an envelope.
+// TODO: Make `UnpackCommand`, etc.
 func Unpack(env *Envelope) (dogma.Message, error) {
 	message := env.GetBody().GetMessage()
 
@@ -277,14 +278,19 @@ func appendOrReplace(values *[]*anypb.Any, value *anypb.Any) {
 }
 
 // marshalAsAny returns v as an [*anypb.Any], converting it if necessary. It
-// panics if x is nil or x cannot be marshaled.
+// panics if x is nil, if x is an empty [*anypb.Any], or if it cannot be
+// marshaled.
 func marshalAsAny(x proto.Message) *anypb.Any {
 	if x == nil {
-		panic("extension value must not be nil")
+		panic("value must not be nil")
 	}
 
-	if v, ok := x.(*anypb.Any); ok {
-		return v
+	if x, ok := x.(*anypb.Any); ok {
+		if err := validateAnyValue(x); err != nil {
+			panic("value must not be an empty google.protobuf.Any")
+		}
+
+		return x
 	}
 
 	v, err := anypb.New(x)

--- a/protobuf/envelopepb/packer_test.go
+++ b/protobuf/envelopepb/packer_test.go
@@ -178,6 +178,96 @@ func TestWithIdempotencyKey(t *testing.T) {
 }
 
 func TestWithExtension(t *testing.T) {
+	t.Run("it panics if x is nil", func(t *testing.T) {
+		ExpectPanic(
+			t,
+			"value must not be nil",
+			func() {
+				WithExtension(nil)
+			},
+		)
+	})
+
+	t.Run("it panics if x is an empty any", func(t *testing.T) {
+		ExpectPanic(
+			t,
+			"value must not be an empty google.protobuf.Any",
+			func() {
+				var x *anypb.Any
+				WithExtension(x)
+			},
+		)
+
+		ExpectPanic(
+			t,
+			"value must not be an empty google.protobuf.Any",
+			func() {
+				WithExtension(&anypb.Any{})
+			},
+		)
+	})
+
+	t.Run("it accepts empty serialized values", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		got := packer.PackCommand(CommandA1, WithExtension(wrapperspb.String("")))
+
+		if len(got.Body.Extensions) != 1 {
+			t.Fatalf("unexpected extension count: got %d, want 1", len(got.Body.Extensions))
+		}
+
+		if got.Body.Extensions[0].GetTypeUrl() != "type.googleapis.com/google.protobuf.StringValue" {
+			t.Fatalf(
+				"unexpected extension type URL: got %q, want %q",
+				got.Body.Extensions[0].GetTypeUrl(),
+				"type.googleapis.com/google.protobuf.StringValue",
+			)
+		}
+
+		if len(got.Body.Extensions[0].GetValue()) != 0 {
+			t.Fatalf(
+				"unexpected extension payload length: got %d, want 0",
+				len(got.Body.Extensions[0].GetValue()),
+			)
+		}
+	})
+
+	t.Run("it accepts typed nil messages", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		var value *wrapperspb.StringValue
+		got := packer.PackCommand(CommandA1, WithExtension(value))
+
+		if len(got.Body.Extensions) != 1 {
+			t.Fatalf("unexpected extension count: got %d, want 1", len(got.Body.Extensions))
+		}
+
+		if got.Body.Extensions[0].GetTypeUrl() != "type.googleapis.com/google.protobuf.StringValue" {
+			t.Fatalf(
+				"unexpected extension type URL: got %q, want %q",
+				got.Body.Extensions[0].GetTypeUrl(),
+				"type.googleapis.com/google.protobuf.StringValue",
+			)
+		}
+
+		if len(got.Body.Extensions[0].GetValue()) != 0 {
+			t.Fatalf(
+				"unexpected extension payload length: got %d, want 0",
+				len(got.Body.Extensions[0].GetValue()),
+			)
+		}
+	})
+
 	t.Run("it adds x to the extensions", func(t *testing.T) {
 		packer := &Packer{
 			Application: &identitypb.Identity{
@@ -262,6 +352,116 @@ func TestWithExtension(t *testing.T) {
 			t,
 			"unexpected extensions",
 			got.Body.Extensions,
+			[]*anypb.Any{wantString, wantInt},
+		)
+	})
+}
+
+func TestWithBaggage(t *testing.T) {
+	t.Run("it panics if x is nil", func(t *testing.T) {
+		ExpectPanic(
+			t,
+			"value must not be nil",
+			func() {
+				WithBaggage(nil)
+			},
+		)
+	})
+
+	t.Run("it panics if x is an empty any", func(t *testing.T) {
+		ExpectPanic(
+			t,
+			"value must not be an empty google.protobuf.Any",
+			func() {
+				WithBaggage(&anypb.Any{})
+			},
+		)
+	})
+
+	t.Run("it adds x to the baggage", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		baggage := wrapperspb.String("baggage")
+		want, err := anypb.New(baggage)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(CommandA1, WithBaggage(baggage))
+
+		if got.Header.Baggage != nil {
+			t.Fatalf("unexpected header baggage: got %#v, want nil", got.Header.Baggage)
+		}
+
+		Expect(
+			t,
+			"unexpected baggage",
+			got.Body.Baggage,
+			[]*anypb.Any{want},
+		)
+	})
+
+	t.Run("it keeps only the last value for a type URL", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		want, err := anypb.New(wrapperspb.String("second"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(
+			CommandA1,
+			WithBaggage(wrapperspb.String("first")),
+			WithBaggage(wrapperspb.String("second")),
+		)
+
+		Expect(
+			t,
+			"unexpected baggage",
+			got.Body.Baggage,
+			[]*anypb.Any{want},
+		)
+	})
+
+	t.Run("it replaces an existing value in place", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		wantString, err := anypb.New(wrapperspb.String("second"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantInt, err := anypb.New(wrapperspb.Int64(42))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(
+			CommandA1,
+			WithBaggage(wrapperspb.String("first")),
+			WithBaggage(wrapperspb.Int64(42)),
+			WithBaggage(wrapperspb.String("second")),
+		)
+
+		Expect(
+			t,
+			"unexpected baggage",
+			got.Body.Baggage,
 			[]*anypb.Any{wantString, wantInt},
 		)
 	})

--- a/protobuf/envelopepb/packer_test.go
+++ b/protobuf/envelopepb/packer_test.go
@@ -10,10 +10,12 @@ import (
 	. "github.com/dogmatiq/enginekit/protobuf/envelopepb"
 	"github.com/dogmatiq/enginekit/protobuf/identitypb"
 	"github.com/dogmatiq/enginekit/protobuf/uuidpb"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-func TestPacker_packAndUnpack(t *testing.T) {
+func TestPacker_PackAndUnpack(t *testing.T) {
 	id := uuidpb.Generate()
 	now := time.Now()
 
@@ -34,7 +36,7 @@ func TestPacker_packAndUnpack(t *testing.T) {
 		},
 	}
 
-	got := packer.Pack(CommandA1)
+	got := packer.PackCommand(CommandA1)
 
 	if err := got.Validate(); err != nil {
 		t.Fatalf("packer produced an invalid envelope: %v", err)
@@ -79,14 +81,14 @@ func TestPacker_packAndUnpack(t *testing.T) {
 		dogma.Message(CommandA1),
 	)
 
-	t.Run("func Pack()", func(t *testing.T) {
+	t.Run("func PackCommand()", func(t *testing.T) {
 		t.Run("it panics if passed an unregistered message", func(t *testing.T) {
 			ExpectPanic(
 				t,
 				"*envelopepb_test.T is not a registered message type",
 				func() {
 					type T struct{ dogma.Command }
-					packer.Pack(&T{})
+					packer.PackCommand(&T{})
 				},
 			)
 		})
@@ -98,7 +100,7 @@ func TestPacker_packAndUnpack(t *testing.T) {
 				func() {
 					type T struct{ CommandStub[func()] }
 					dogma.RegisterCommand[*T]("622003a4-01a5-4c77-8a4c-cb36b51994e7")
-					packer.Pack(&T{})
+					packer.PackCommand(&T{})
 				},
 			)
 		})
@@ -112,7 +114,7 @@ func TestPacker_packAndUnpack(t *testing.T) {
 				t,
 				"invalid header: invalid source: invalid site (/00000000-0000-0000-0000-000000000000): invalid name: must be between 1 and 255 bytes",
 				func() {
-					packer.Pack(CommandA1)
+					packer.PackCommand(CommandA1)
 				},
 			)
 		})
@@ -160,125 +162,6 @@ func TestPacker_packAndUnpack(t *testing.T) {
 		})
 	})
 }
-
-func TestWithCause(t *testing.T) {
-	packer := &Packer{
-		Application: &identitypb.Identity{
-			Name: "app",
-			Key:  uuidpb.Generate(),
-		},
-	}
-
-	root := packer.Pack(CommandA1)
-	cause := packer.Pack(EventA1, WithCause(root))
-	got := packer.Pack(CommandA2, WithCause(cause))
-
-	if !got.Header.CausationId.Equal(cause.Body.MessageId) {
-		t.Fatalf("unexpected causation ID: got %s, want %s", got.Header.CausationId, cause.Body.MessageId)
-	}
-
-	if !got.Header.CorrelationId.Equal(cause.Header.CorrelationId) {
-		t.Fatalf("unexpected correlation ID: got %s, want %s", got.Header.CorrelationId, root.Body.MessageId)
-	}
-}
-
-func TestWithHandler(t *testing.T) {
-	packer := &Packer{
-		Application: &identitypb.Identity{
-			Name: "app",
-			Key:  uuidpb.Generate(),
-		},
-	}
-
-	handler := &identitypb.Identity{
-		Name: "handler",
-		Key:  uuidpb.Generate(),
-	}
-
-	got := packer.Pack(CommandA1, WithHandler(handler))
-
-	if !got.Header.Source.Handler.Equal(handler) {
-		t.Fatalf("unexpected handler: got %s, want %s", got.Header.Source.Handler, handler)
-	}
-}
-
-func TestWithInstanceID(t *testing.T) {
-	packer := &Packer{
-		Application: &identitypb.Identity{
-			Name: "app",
-			Key:  uuidpb.Generate(),
-		},
-	}
-
-	got := packer.Pack(
-		CommandA1,
-		WithInstanceID("instance"),
-
-		// We cannot have an instance ID without saying which handler the
-		// instance is managed by.
-		WithHandler(&identitypb.Identity{
-			Name: "handler",
-			Key:  uuidpb.Generate(),
-		}),
-	)
-
-	if got.Header.Source.InstanceId != "instance" {
-		t.Fatalf("unexpected instance ID: got %s, want instance", got.Header.Source.InstanceId)
-	}
-}
-
-func TestWithCreatedAt(t *testing.T) {
-	packer := &Packer{
-		Application: &identitypb.Identity{
-			Name: "app",
-			Key:  uuidpb.Generate(),
-		},
-		Now: func() time.Time {
-			t.Fatal("unexpected call")
-			return time.Time{}
-		},
-	}
-
-	want := time.Now().Add(-time.Hour)
-
-	got := packer.Pack(
-		CommandA1,
-		WithCreatedAt(want),
-	).Body.CreatedAt.AsTime()
-
-	if !got.Equal(want) {
-		t.Fatalf("unexpected creation time: got %s, want %s", got, want)
-	}
-}
-
-func TestWithScheduledFor(t *testing.T) {
-	packer := &Packer{
-		Application: &identitypb.Identity{
-			Name: "app",
-			Key:  uuidpb.Generate(),
-		},
-	}
-
-	want := time.Now().Add(time.Hour)
-
-	got := packer.Pack(
-		TimeoutA1,
-		WithScheduledFor(want),
-
-		// We cannot have a "scheduled-for" time without saying which handler
-		// and process instance produced the timeout message.
-		WithHandler(&identitypb.Identity{
-			Name: "handler",
-			Key:  uuidpb.Generate(),
-		}),
-		WithInstanceID("instance"),
-	).Body.ScheduledFor.AsTime()
-
-	if !got.Equal(want) {
-		t.Fatalf("unexpected scheduled time: got %s, want %s", got, want)
-	}
-}
-
 func TestWithIdempotencyKey(t *testing.T) {
 	packer := &Packer{
 		Application: &identitypb.Identity{
@@ -287,9 +170,99 @@ func TestWithIdempotencyKey(t *testing.T) {
 		},
 	}
 
-	got := packer.Pack(CommandA1, WithIdempotencyKey("test-key"))
+	got := packer.PackCommand(CommandA1, WithIdempotencyKey("test-key"))
 
 	if got.Body.IdempotencyKey != "test-key" {
 		t.Fatalf("unexpected idempotency key: got %q, want %q", got.Body.IdempotencyKey, "test-key")
 	}
+}
+
+func TestWithExtension(t *testing.T) {
+	t.Run("it adds x to the extensions", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		extension := wrapperspb.String("extension")
+		want, err := anypb.New(extension)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(CommandA1, WithExtension(extension))
+
+		if got.Header.Extensions != nil {
+			t.Fatalf("unexpected header extensions: got %#v, want nil", got.Header.Extensions)
+		}
+
+		Expect(
+			t,
+			"unexpected extensions",
+			got.Body.Extensions,
+			[]*anypb.Any{want},
+		)
+	})
+
+	t.Run("it keeps only the last value for a type URL", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		want, err := anypb.New(wrapperspb.String("second"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(
+			CommandA1,
+			WithExtension(wrapperspb.String("first")),
+			WithExtension(wrapperspb.String("second")),
+		)
+
+		Expect(
+			t,
+			"unexpected extensions",
+			got.Body.Extensions,
+			[]*anypb.Any{want},
+		)
+	})
+
+	t.Run("it replaces an existing value in place", func(t *testing.T) {
+		packer := &Packer{
+			Application: &identitypb.Identity{
+				Name: "app",
+				Key:  uuidpb.Generate(),
+			},
+		}
+
+		wantString, err := anypb.New(wrapperspb.String("second"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantInt, err := anypb.New(wrapperspb.Int64(42))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := packer.PackCommand(
+			CommandA1,
+			WithExtension(wrapperspb.String("first")),
+			WithExtension(wrapperspb.Int64(42)),
+			WithExtension(wrapperspb.String("second")),
+		)
+
+		Expect(
+			t,
+			"unexpected extensions",
+			got.Body.Extensions,
+			[]*anypb.Any{wantString, wantInt},
+		)
+	})
 }

--- a/x/xrapid/envelope.go
+++ b/x/xrapid/envelope.go
@@ -3,6 +3,7 @@ package xrapid
 import (
 	"github.com/dogmatiq/enginekit/protobuf/envelopepb"
 	"github.com/dogmatiq/enginekit/protobuf/uuidpb"
+	anypb "google.golang.org/protobuf/types/known/anypb"
 	"pgregory.net/rapid"
 )
 
@@ -11,6 +12,15 @@ import (
 // By design, the message type and data encoded within the envelope is not
 // necessarily valid.
 func Envelope() *rapid.Generator[*envelopepb.Envelope] {
+	anyValue := rapid.Custom(
+		func(t *rapid.T) *anypb.Any {
+			return &anypb.Any{
+				TypeUrl: rapid.StringN(1, -1, -1).Draw(t, "extension type URL"),
+				Value:   rapid.SliceOf(rapid.Byte()).Draw(t, "extension value"),
+			}
+		},
+	)
+
 	return rapid.Custom(
 		func(t *rapid.T) *envelopepb.Envelope {
 			env := &envelopepb.Envelope{
@@ -31,10 +41,8 @@ func Envelope() *rapid.Generator[*envelopepb.Envelope] {
 						TypeId:      uuidpb.Generate(),
 						Data:        rapid.SliceOf(rapid.Byte()).Draw(t, "data"),
 					},
-					Extensions: &envelopepb.Extensions{
-						Attributes: rapid.MapOf(rapid.String(), rapid.String()).Draw(t, "attributes"),
-						Baggage:    rapid.MapOf(rapid.String(), rapid.String()).Draw(t, "baggage"),
-					},
+					Extensions: rapid.SliceOf(anyValue).Draw(t, "extensions"),
+					Baggage:    rapid.SliceOf(anyValue).Draw(t, "baggage"),
 				},
 			}
 


### PR DESCRIPTION
## Summary

- flatten envelope extensions and baggage onto header/body as repeated `google.protobuf.Any` fields
- refactor the envelope packing API around `PackCommand()`, `PackEffects()`, and `EffectPacker`
- normalize extension and baggage handling in packers and update protobuf generators and tests accordingly

## Testing

- `make test`
