### PR TITLE
Add Implementation() method to handler config types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
-- Added `config.UntypedAggregateMessageHandler` and
-  `UntypedProcessMessageHandler` interfaces.
-- Added `Implementation()` method to `config.Aggregate`, `Process`,
-  `Integration`, and `Projection` types.
+- Added `UntypedAggregateMessageHandler` and `UntypedProcessMessageHandler`
+  interfaces to the `config` package.
+- Added `Implementation()` method to `Aggregate`, `Process`, `Integration`, and
+  `Projection` types in the `config` package.
 
 ## [0.24.0] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ The format is based on [Keep a Changelog], and this project adheres to
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 [bc]: https://github.com/dogmatiq/.github/blob/main/VERSIONING.md#changelogs
 
+## [Unreleased]
+
+### Added
+
+- Added `config.UntypedAggregateMessageHandler` and
+  `UntypedProcessMessageHandler` interfaces.
+- Added `Implementation()` method to `config.Aggregate`, `Process`,
+  `Integration`, and `Projection` types.
+
 ## [0.24.0] - 2026-04-25
 
 ### Changed

--- a/config/aggregate.go
+++ b/config/aggregate.go
@@ -46,6 +46,16 @@ func (h *Aggregate) Interface() dogma.AggregateMessageHandler[dogma.AggregateRoo
 	return resolveInterface(h, h.Source)
 }
 
+// Implementation returns the unwrapped implementation of the handler.
+//
+// It returns the handler value as provided by the application, without the
+// type-erasure wrapper applied by [dogma.UntypedAggregateMessageHandler].
+//
+// It panics if the configuration was not built from a live handler.
+func (h *Aggregate) Implementation() UntypedAggregateMessageHandler {
+	return dogma.UnwrapHandler(h.Interface()).(UntypedAggregateMessageHandler)
+}
+
 func (h *Aggregate) String() string {
 	return stringifyEntity(h)
 }

--- a/config/aggregate.go
+++ b/config/aggregate.go
@@ -50,8 +50,6 @@ func (h *Aggregate) Interface() dogma.AggregateMessageHandler[dogma.AggregateRoo
 //
 // It returns the handler value as provided by the application, without the
 // type-erasure wrapper applied by [dogma.UntypedAggregateMessageHandler].
-//
-// It panics if the configuration was not built from a live handler.
 func (h *Aggregate) Implementation() UntypedAggregateMessageHandler {
 	return dogma.UnwrapHandler(h.Interface()).(UntypedAggregateMessageHandler)
 }

--- a/config/aggregate_test.go
+++ b/config/aggregate_test.go
@@ -464,4 +464,24 @@ func TestAggregate(t *testing.T) {
 			)
 		})
 	})
+
+	t.Run("func Implementation()", func(t *testing.T) {
+		t.Run("it returns the unwrapped handler", func(t *testing.T) {
+			inner := &AggregateMessageHandlerStub[*AggregateRootStub]{
+				ConfigureFunc: func(c dogma.AggregateConfigurer) {
+					c.Identity("name", "19cb98d5-dd17-4daf-ae00-1b413b7b899a")
+					c.Routes(
+						dogma.HandlesCommand[*CommandStub[TypeA]](),
+						dogma.RecordsEvent[*EventStub[TypeA]](),
+					)
+				},
+			}
+
+			cfg := runtimeconfig.FromAggregate(inner)
+
+			if cfg.Implementation() != inner {
+				t.Fatal("expected Implementation() to return the unwrapped handler")
+			}
+		})
+	})
 }

--- a/config/implementation.go
+++ b/config/implementation.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"context"
+
+	"github.com/dogmatiq/dogma"
+)
+
+// UntypedAggregateMessageHandler is a subset of
+// [dogma.AggregateMessageHandler] that includes only the methods that do not
+// depend on the type parameter R.
+type UntypedAggregateMessageHandler interface {
+	Configure(dogma.AggregateConfigurer)
+	RouteCommandToInstance(dogma.Command) string
+}
+
+// UntypedProcessMessageHandler is a subset of [dogma.ProcessMessageHandler]
+// that includes only the methods that do not depend on the type parameter R.
+type UntypedProcessMessageHandler interface {
+	Configure(dogma.ProcessConfigurer)
+	RouteEventToInstance(context.Context, dogma.Event) (string, bool, error)
+}

--- a/config/integration.go
+++ b/config/integration.go
@@ -50,14 +50,13 @@ func (h *Integration) ConcurrencyPreference() dogma.ConcurrencyPreference {
 	return resolveConcurrencyPreference(h, h.ConcurrencyPreferences)
 }
 
-// Interface returns the [dogma.Application] that the entity represents.
+// Interface returns the [dogma.IntegrationMessageHandler] that the entity
+// represents.
 func (h *Integration) Interface() dogma.IntegrationMessageHandler {
 	return resolveInterface(h, h.Source)
 }
 
 // Implementation returns the unwrapped implementation of the handler.
-//
-// It panics if the configuration was not built from a live handler.
 func (h *Integration) Implementation() dogma.IntegrationMessageHandler {
 	return dogma.UnwrapHandler(h.Interface()).(dogma.IntegrationMessageHandler)
 }

--- a/config/integration.go
+++ b/config/integration.go
@@ -55,6 +55,13 @@ func (h *Integration) Interface() dogma.IntegrationMessageHandler {
 	return resolveInterface(h, h.Source)
 }
 
+// Implementation returns the unwrapped implementation of the handler.
+//
+// It panics if the configuration was not built from a live handler.
+func (h *Integration) Implementation() dogma.IntegrationMessageHandler {
+	return dogma.UnwrapHandler(h.Interface()).(dogma.IntegrationMessageHandler)
+}
+
 func (h *Integration) String() string {
 	return stringifyEntity(h)
 }

--- a/config/integration_test.go
+++ b/config/integration_test.go
@@ -411,4 +411,23 @@ func TestIntegration(t *testing.T) {
 			)
 		})
 	})
+
+	t.Run("func Implementation()", func(t *testing.T) {
+		t.Run("it returns the unwrapped handler", func(t *testing.T) {
+			inner := &IntegrationMessageHandlerStub{
+				ConfigureFunc: func(c dogma.IntegrationConfigurer) {
+					c.Identity("name", "19cb98d5-dd17-4daf-ae00-1b413b7b899a")
+					c.Routes(
+						dogma.HandlesCommand[*CommandStub[TypeA]](),
+					)
+				},
+			}
+
+			cfg := runtimeconfig.FromIntegration(inner)
+
+			if cfg.Implementation() != inner {
+				t.Fatal("expected Implementation() to return the unwrapped handler")
+			}
+		})
+	})
 }

--- a/config/process.go
+++ b/config/process.go
@@ -46,6 +46,16 @@ func (h *Process) Interface() dogma.ProcessMessageHandler[dogma.ProcessRoot] {
 	return resolveInterface(h, h.Source)
 }
 
+// Implementation returns the unwrapped implementation of the handler.
+//
+// It returns the handler value as provided by the application, without the
+// type-erasure wrapper applied by [dogma.UntypedProcessMessageHandler].
+//
+// It panics if the configuration was not built from a live handler.
+func (h *Process) Implementation() UntypedProcessMessageHandler {
+	return dogma.UnwrapHandler(h.Interface()).(UntypedProcessMessageHandler)
+}
+
 func (h *Process) String() string {
 	return stringifyEntity(h)
 }

--- a/config/process.go
+++ b/config/process.go
@@ -50,8 +50,6 @@ func (h *Process) Interface() dogma.ProcessMessageHandler[dogma.ProcessRoot] {
 //
 // It returns the handler value as provided by the application, without the
 // type-erasure wrapper applied by [dogma.UntypedProcessMessageHandler].
-//
-// It panics if the configuration was not built from a live handler.
 func (h *Process) Implementation() UntypedProcessMessageHandler {
 	return dogma.UnwrapHandler(h.Interface()).(UntypedProcessMessageHandler)
 }

--- a/config/process_test.go
+++ b/config/process_test.go
@@ -483,4 +483,25 @@ func TestProcess(t *testing.T) {
 			)
 		})
 	})
+
+	t.Run("func Implementation()", func(t *testing.T) {
+		t.Run("it returns the unwrapped handler", func(t *testing.T) {
+			inner := &ProcessMessageHandlerStub[*ProcessRootStub]{
+				ConfigureFunc: func(c dogma.ProcessConfigurer) {
+					c.Identity("name", "19cb98d5-dd17-4daf-ae00-1b413b7b899a")
+					c.Routes(
+						dogma.HandlesEvent[*EventStub[TypeA]](),
+						dogma.ExecutesCommand[*CommandStub[TypeA]](),
+						dogma.SchedulesTimeout[*TimeoutStub[TypeA]](),
+					)
+				},
+			}
+
+			cfg := runtimeconfig.FromProcess(inner)
+
+			if cfg.Implementation() != inner {
+				t.Fatal("expected Implementation() to return the unwrapped handler")
+			}
+		})
+	})
 }

--- a/config/projection.go
+++ b/config/projection.go
@@ -55,6 +55,13 @@ func (h *Projection) Interface() dogma.ProjectionMessageHandler {
 	return resolveInterface(h, h.Source)
 }
 
+// Implementation returns the unwrapped implementation of the handler.
+//
+// It panics if the configuration was not built from a live handler.
+func (h *Projection) Implementation() dogma.ProjectionMessageHandler {
+	return dogma.UnwrapHandler(h.Interface()).(dogma.ProjectionMessageHandler)
+}
+
 func (h *Projection) String() string {
 	return stringifyEntity(h)
 }

--- a/config/projection.go
+++ b/config/projection.go
@@ -50,14 +50,13 @@ func (h *Projection) ConcurrencyPreference() dogma.ConcurrencyPreference {
 	return resolveConcurrencyPreference(h, h.ConcurrencyPreferences)
 }
 
-// Interface returns the [dogma.Application] that the entity represents.
+// Interface returns the [dogma.ProjectionMessageHandler] that the entity
+// represents.
 func (h *Projection) Interface() dogma.ProjectionMessageHandler {
 	return resolveInterface(h, h.Source)
 }
 
 // Implementation returns the unwrapped implementation of the handler.
-//
-// It panics if the configuration was not built from a live handler.
 func (h *Projection) Implementation() dogma.ProjectionMessageHandler {
 	return dogma.UnwrapHandler(h.Interface()).(dogma.ProjectionMessageHandler)
 }

--- a/config/projection_test.go
+++ b/config/projection_test.go
@@ -404,4 +404,23 @@ func TestProjection(t *testing.T) {
 			)
 		})
 	})
+
+	t.Run("func Implementation()", func(t *testing.T) {
+		t.Run("it returns the unwrapped handler", func(t *testing.T) {
+			inner := &ProjectionMessageHandlerStub{
+				ConfigureFunc: func(c dogma.ProjectionConfigurer) {
+					c.Identity("name", "19cb98d5-dd17-4daf-ae00-1b413b7b899a")
+					c.Routes(
+						dogma.HandlesEvent[*EventStub[TypeA]](),
+					)
+				},
+			}
+
+			cfg := runtimeconfig.FromProjection(inner)
+
+			if cfg.Implementation() != inner {
+				t.Fatal("expected Implementation() to return the unwrapped handler")
+			}
+		})
+	})
 }


### PR DESCRIPTION
Expose the unwrapped handler implementation from handler configs, avoiding the need for consumers to call `dogma.UnwrapHandler()` at every call site.

## Changes

- Add `UntypedAggregateMessageHandler` and `UntypedProcessMessageHandler` interfaces in the `config` package, containing only the methods that do not depend on the type parameter `R`.
- Add `Implementation()` method to `Aggregate`, `Process`, `Integration`, and `Projection` config types.
  - For `Aggregate` and `Process`, returns the partial interface (`UntypedAggregateMessageHandler` / `UntypedProcessMessageHandler`).
  - For `Integration` and `Projection`, returns the full dogma interface type (no `R` to erase).
- All four methods call `dogma.UnwrapHandler()` on the `Interface()` value to strip any wrappers.

Closes #136