### PR TITLE
Add text marshaling to UUID

### DIFF
--- a/protobuf/uuidpb/uuid.go
+++ b/protobuf/uuidpb/uuid.go
@@ -64,41 +64,11 @@ func Derive[T ~string | ~[]byte](ns *UUID, names ...T) *UUID {
 
 // Parse parses an RFC 9562 "hex-and-dash" UUID string.
 func Parse(str string) (*UUID, error) {
-	if len(str) != 36 {
-		return nil, errors.New("invalid UUID format, expected 36 characters")
+	uuid := &UUID{}
+	if err := uuid.UnmarshalText([]byte(str)); err != nil {
+		return nil, err
 	}
-
-	var (
-		upper, lower uint64
-		target       = &upper
-		shift        = 60
-	)
-
-	for index := range 36 {
-		switch index {
-		case 18:
-			target = &lower
-			shift = 60
-			fallthrough
-		case 8, 13, 23:
-			if str[index] != '-' {
-				return nil, fmt.Errorf("invalid UUID format, expected hyphen at position %d", index)
-			}
-		default:
-			value, err := fromHex(str, index)
-			if err != nil {
-				return nil, err
-			}
-
-			*target |= uint64(value) << shift
-			shift -= 4
-		}
-	}
-
-	return NewUUIDBuilder().
-		WithUpper(upper).
-		WithLower(lower).
-		Build(), nil
+	return uuid, nil
 }
 
 // MustParse parses an RFC 9562 "hex-and-dash" UUID string, or panics if unable
@@ -329,7 +299,52 @@ func (x *UUID) AsByteArray() [16]byte {
 
 // AsString returns the UUID as an RFC 9562 string.
 func (x *UUID) AsString() string {
-	return asString(x.GetUpper(), x.GetLower())
+	data := asHex(x.GetUpper(), x.GetLower())
+	return string(data[:])
+}
+
+// MarshalText implements the [encoding.TextMarshaler] interface.
+func (x *UUID) MarshalText() ([]byte, error) {
+	data := asHex(x.GetUpper(), x.GetLower())
+	return data[:], nil
+}
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (x *UUID) UnmarshalText(text []byte) error {
+	if len(text) != 36 {
+		return errors.New("invalid UUID format, expected 36 characters")
+	}
+
+	x.xxx_hidden_Upper = 0
+	x.xxx_hidden_Lower = 0
+
+	var (
+		target = &x.xxx_hidden_Upper
+		shift  = 60
+	)
+
+	for index, digit := range text {
+		switch index {
+		case 18:
+			target = &x.xxx_hidden_Lower
+			shift = 60
+			fallthrough
+		case 8, 13, 23:
+			if digit != '-' {
+				return fmt.Errorf("invalid UUID format, expected hyphen at position %d", index)
+			}
+		default:
+			value := fromHexMap[digit]
+			if value == bad {
+				return fmt.Errorf("invalid UUID format, expected hex digit at position %d", index)
+			}
+
+			*target |= uint64(value) << shift
+			shift -= 4
+		}
+	}
+
+	return nil
 }
 
 // DapperString implements [github.com/dogmatiq/dapper.Stringer].
@@ -474,12 +489,13 @@ type plain struct {
 
 // DapperString implements [github.com/dogmatiq/dapper.Stringer].
 func (k plain) DapperString() string {
-	return asString(k.upper, k.lower)
+	data := asHex(k.upper, k.lower)
+	return string(data[:])
 }
 
-// asString returns the string representation of a UUID with the given upper and
-// lower components.
-func asString(upper, lower uint64) string {
+// asHex returns the RFC 9562 "hex-and-dash" representation of a UUID with
+// the given upper and lower components.
+func asHex(upper, lower uint64) [36]byte {
 	var str [36]byte
 
 	source := &upper
@@ -500,7 +516,7 @@ func asString(upper, lower uint64) string {
 		}
 	}
 
-	return string(str[:])
+	return str
 }
 
 func compare(

--- a/protobuf/uuidpb/uuid_test.go
+++ b/protobuf/uuidpb/uuid_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	unsafe "unsafe"
 
 	"github.com/dogmatiq/dapper"
 	. "github.com/dogmatiq/enginekit/protobuf/uuidpb"
@@ -144,10 +143,8 @@ func TestParse_OnlyAllocatesTheUUID(t *testing.T) {
 		Parse("a967a8b9-3f9c-4918-9a41-19577be5fec5")
 	})
 
-	const size = unsafe.Sizeof(UUID{})
-
-	if allocs > float64(size) {
-		t.Fatalf("expected maximum allocation of %d bytes, got %f", size, allocs)
+	if allocs != 1 {
+		t.Fatalf("expected exactly 1 allocation, got %f", allocs)
 	}
 }
 
@@ -686,6 +683,66 @@ func TestUUID_AsString(t *testing.T) {
 				t.Fatalf("got %q, want %q", actual, c.Expect)
 			}
 		})
+	}
+}
+
+func TestUUID_MarshalText(t *testing.T) {
+	t.Parallel()
+
+	subject := NewUUIDBuilder().
+		WithUpper(0xa967a8b93f9c4918).
+		WithLower(0x9a4119577be5fec5).
+		Build()
+
+	text, err := subject.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(text), "a967a8b9-3f9c-4918-9a41-19577be5fec5"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestUUID_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it populates the UUID from text", func(t *testing.T) {
+		t.Parallel()
+
+		var subject UUID
+		if err := subject.UnmarshalText([]byte("a967a8b9-3f9c-4918-9a41-19577be5fec5")); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := subject.GetUpper(), uint64(0xa967a8b93f9c4918); got != want {
+			t.Fatalf("upper: got %#x, want %#x", got, want)
+		}
+		if got, want := subject.GetLower(), uint64(0x9a4119577be5fec5); got != want {
+			t.Fatalf("lower: got %#x, want %#x", got, want)
+		}
+	})
+
+	t.Run("it returns an error for invalid text", func(t *testing.T) {
+		t.Parallel()
+
+		var subject UUID
+		if err := subject.UnmarshalText([]byte("not-a-uuid")); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
+}
+
+func TestUUID_UnmarshalText_DoesNotAlloc(t *testing.T) {
+	text := []byte("a967a8b9-3f9c-4918-9a41-19577be5fec5")
+	var subject UUID
+
+	allocs := testing.AllocsPerRun(100, func() {
+		subject.UnmarshalText(text)
+	})
+
+	if allocs != 0 {
+		t.Fatalf("expected zero allocations, got %f", allocs)
 	}
 }
 


### PR DESCRIPTION
Implement `encoding.TextMarshaler` and `encoding.TextUnmarshaler` on `UUID`.

## Changes

- Add `MarshalText()` — returns the RFC 9562 hex-and-dash string as `[]byte`
- Add `UnmarshalText()` — parses directly into the receiver's hidden fields, zero allocations
- `Parse()` now delegates to `UnmarshalText`, eliminating duplicate parsing logic
- Rename internal `asString()` to `asHex()`, returning `[36]byte` instead of `string` — avoids a double allocation in `MarshalText`
- Tighten `TestParse_OnlyAllocatesTheUUID` to assert exactly 1 allocation (remove misleading `unsafe.Sizeof` comparison)
- Add `TestUUID_UnmarshalText_DoesNotAlloc` to verify zero-allocation unmarshal