### PR TITLE
Add MarshalText/UnmarshalText to identitypb.Identity

### DIFF
--- a/protobuf/envelopepb/envelope_test.go
+++ b/protobuf/envelopepb/envelope_test.go
@@ -129,21 +129,21 @@ func TestEnvelope_Validate(t *testing.T) {
 				newEnvelope(func(e *Envelope) {
 					e.GetHeader().GetSource().SetSite(&identitypb.Identity{})
 				}),
-				"invalid header: invalid source: invalid site (/00000000-0000-0000-0000-000000000000): invalid name: must be between 1 and 255 bytes",
+				"invalid header: invalid source: invalid site (00000000-0000-0000-0000-000000000000 ?): invalid name: must be between 1 and 255 bytes",
 			},
 			{
 				"invalid source application",
 				newEnvelope(func(e *Envelope) {
 					e.GetHeader().GetSource().SetApplication(&identitypb.Identity{})
 				}),
-				"invalid header: invalid source: invalid application (/00000000-0000-0000-0000-000000000000): invalid name: must be between 1 and 255 bytes",
+				"invalid header: invalid source: invalid application (00000000-0000-0000-0000-000000000000 ?): invalid name: must be between 1 and 255 bytes",
 			},
 			{
 				"invalid source handler",
 				newEnvelope(func(e *Envelope) {
 					e.GetHeader().GetSource().SetHandler(&identitypb.Identity{})
 				}),
-				"invalid header: invalid source: invalid handler (/00000000-0000-0000-0000-000000000000): invalid name: must be between 1 and 255 bytes",
+				"invalid header: invalid source: invalid handler (00000000-0000-0000-0000-000000000000 ?): invalid name: must be between 1 and 255 bytes",
 			},
 			{
 				"source instance ID without source handler",

--- a/protobuf/envelopepb/packer_test.go
+++ b/protobuf/envelopepb/packer_test.go
@@ -118,7 +118,7 @@ func TestPacker_PackAndUnpack(t *testing.T) {
 
 			ExpectPanic(
 				t,
-				"invalid header: invalid source: invalid site (/00000000-0000-0000-0000-000000000000): invalid name: must be between 1 and 255 bytes",
+				"invalid header: invalid source: invalid site (00000000-0000-0000-0000-000000000000 ?): invalid name: must be between 1 and 255 bytes",
 				func() {
 					packer.PackCommand(CommandA1)
 				},

--- a/protobuf/identitypb/identity.go
+++ b/protobuf/identitypb/identity.go
@@ -3,6 +3,7 @@ package identitypb
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	uuidpb "github.com/dogmatiq/enginekit/protobuf/uuidpb"
 )
@@ -70,15 +71,58 @@ func (x *Identity) Validate() error {
 	return nil
 }
 
-// Format implements the fmt.Formatter interface, allowing UUIDs to be formatted
-// with functions from the fmt package.
+// MarshalText implements the [encoding.TextMarshaler] interface.
+//
+// The text representation is the UUID key followed by a space and the name,
+// e.g. "5195fe85-eb3f-4121-84b0-be72cbc5722f handler-name".
+func (x *Identity) MarshalText() ([]byte, error) {
+	text, err := x.GetKey().MarshalText()
+	if err != nil {
+		return nil, err
+	}
+
+	text = slices.Grow(text, 1+len(x.xxx_hidden_Name))
+	text = append(text, ' ')
+	text = append(text, x.xxx_hidden_Name...)
+
+	return text, nil
+}
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (x *Identity) UnmarshalText(text []byte) error {
+	if len(text) < 38 {
+		return errors.New("invalid identity format, expected UUID followed by a space and name")
+	}
+
+	if text[36] != ' ' {
+		return errors.New("invalid identity format, expected space after UUID")
+	}
+
+	var key uuidpb.UUID
+	if err := key.UnmarshalText(text[:36]); err != nil {
+		return fmt.Errorf("invalid key: %w", err)
+	}
+
+	x.SetKey(&key)
+	x.SetName(string(text[37:]))
+
+	return x.Validate()
+}
+
+// Format implements the fmt.Formatter interface, allowing identities to be
+// formatted with functions from the fmt package.
 func (x *Identity) Format(f fmt.State, verb rune) {
 	format := fmt.FormatString(f, verb)
 
-	// If we're formatting as a string, use a slash separated notation.
+	// If we're formatting as a string, show the UUID followed by the name. A
+	// question mark is used as a placeholder when the name is empty.
 	if verb == 's' {
-		str := fmt.Sprintf("%s/%s", x.GetName(), x.GetKey())
-		fmt.Fprintf(f, format, str)
+		name := x.GetName()
+		if name == "" {
+			name = "?"
+		}
+
+		fmt.Fprintf(f, "%s %s", x.GetKey(), name)
 		return
 	}
 

--- a/protobuf/identitypb/identity.go
+++ b/protobuf/identitypb/identity.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	uuidpb "github.com/dogmatiq/enginekit/protobuf/uuidpb"
 )
@@ -76,14 +77,15 @@ func (x *Identity) Validate() error {
 // The text representation is the UUID key followed by a space and the name,
 // e.g. "5195fe85-eb3f-4121-84b0-be72cbc5722f handler-name".
 func (x *Identity) MarshalText() ([]byte, error) {
-	text, err := x.GetKey().MarshalText()
-	if err != nil {
+	if err := x.Validate(); err != nil {
 		return nil, err
 	}
 
-	text = slices.Grow(text, 1+len(x.xxx_hidden_Name))
+	name := x.GetName()
+	text, _ := x.GetKey().MarshalText()
+	text = slices.Grow(text, 1+len(name))
 	text = append(text, ' ')
-	text = append(text, x.xxx_hidden_Name...)
+	text = append(text, name...)
 
 	return text, nil
 }
@@ -122,7 +124,13 @@ func (x *Identity) Format(f fmt.State, verb rune) {
 			name = "?"
 		}
 
-		fmt.Fprintf(f, "%s %s", x.GetKey(), name)
+		var b strings.Builder
+		key, _ := x.GetKey().MarshalText()
+		b.Write(key)
+		b.WriteByte(' ')
+		b.WriteString(name)
+
+		fmt.Fprintf(f, format, b.String())
 		return
 	}
 

--- a/protobuf/identitypb/identity_test.go
+++ b/protobuf/identitypb/identity_test.go
@@ -267,6 +267,19 @@ func TestIdentity_MarshalText(t *testing.T) {
 			t.Fatalf("got %q, want %q", text, want)
 		}
 	})
+
+	t.Run("it returns an error for an invalid identity", func(t *testing.T) {
+		t.Parallel()
+
+		subject := NewIdentityBuilder().
+			WithName("").
+			WithKey(uuidpb.Generate()).
+			Build()
+
+		if _, err := subject.MarshalText(); err == nil {
+			t.Fatal("expected an error")
+		}
+	})
 }
 
 func TestIdentity_MarshalText_OnlyAllocatesTheResultAndUUIDText(t *testing.T) {

--- a/protobuf/identitypb/identity_test.go
+++ b/protobuf/identitypb/identity_test.go
@@ -210,9 +210,9 @@ func TestIdentity_Format(t *testing.T) {
 		Want   string
 	}{
 		{
-			"it formats as a slash-separated name/key string",
+			"it formats as a UUID-prefixed string",
 			"%s",
-			`<name>/a967a8b9-3f9c-4918-9a41-19577be5fec5`,
+			`a967a8b9-3f9c-4918-9a41-19577be5fec5 <name>`,
 		},
 		{
 			"it formats as a Go constructor expression",
@@ -240,6 +240,110 @@ func TestIdentity_Format(t *testing.T) {
 			t.Errorf("got %q, want raw struct output", actual)
 		}
 	})
+}
+
+func TestIdentity_MarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it produces the expected text", func(t *testing.T) {
+		t.Parallel()
+
+		subject := New(
+			"<name>",
+			uuidpb.
+				NewUUIDBuilder().
+				WithUpper(0xa967a8b93f9c4918).
+				WithLower(0x9a4119577be5fec5).
+				Build(),
+		)
+
+		text, err := subject.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		want := "a967a8b9-3f9c-4918-9a41-19577be5fec5 <name>"
+		if string(text) != want {
+			t.Fatalf("got %q, want %q", text, want)
+		}
+	})
+}
+
+func TestIdentity_MarshalText_OnlyAllocatesTheResultAndUUIDText(t *testing.T) {
+	subject := New("<name>", uuidpb.Generate())
+
+	allocs := testing.AllocsPerRun(100, func() {
+		subject.MarshalText()
+	})
+
+	if allocs != 2 {
+		t.Fatalf("expected 2 allocations, got %f", allocs)
+	}
+}
+
+func TestIdentity_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it parses a valid identity", func(t *testing.T) {
+		t.Parallel()
+
+		var subject Identity
+		err := subject.UnmarshalText([]byte("a967a8b9-3f9c-4918-9a41-19577be5fec5 <name>"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expect := New(
+			"<name>",
+			uuidpb.
+				NewUUIDBuilder().
+				WithUpper(0xa967a8b93f9c4918).
+				WithLower(0x9a4119577be5fec5).
+				Build(),
+		)
+
+		if !subject.Equal(expect) {
+			t.Fatalf("got %s, want %s", &subject, expect)
+		}
+	})
+
+	t.Run("it returns an error for invalid input", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			Desc  string
+			Input string
+		}{
+			{"too short", "abc"},
+			{"missing space after UUID", "a967a8b9-3f9c-4918-9a41-19577be5fec5x"},
+			{"malformed UUID", "not-a-valid-uuid-at-all-nope-nope!! <name>"},
+			{"empty name", "a967a8b9-3f9c-4918-9a41-19577be5fec5 "},
+		}
+
+		for _, c := range cases {
+			t.Run(c.Desc, func(t *testing.T) {
+				t.Parallel()
+
+				var subject Identity
+				if err := subject.UnmarshalText([]byte(c.Input)); err == nil {
+					t.Fatal("expected an error")
+				}
+			})
+		}
+	})
+}
+
+func TestIdentity_UnmarshalText_OnlyAllocatesTheNameAndKey(t *testing.T) {
+	text := []byte("a967a8b9-3f9c-4918-9a41-19577be5fec5 <name>")
+	subject := New("<name>", uuidpb.Generate())
+
+	allocs := testing.AllocsPerRun(100, func() {
+		subject.UnmarshalText(text)
+	})
+
+	if allocs != 2 {
+		t.Fatalf("expected 2 allocations, got %f", allocs)
+	}
 }
 
 func TestIdentity_Equal(t *testing.T) {


### PR DESCRIPTION
Implement `encoding.TextMarshaler` and `encoding.TextUnmarshaler` for `identitypb.Identity`.

## Text format

The text representation is `<uuid> <name>`, e.g.:

```
5195fe85-eb3f-4121-84b0-be72cbc5722f handler-name
```

Parsing uses fixed-width extraction (UUID is always 36 chars) rather than delimiter splitting, since names may contain spaces.

## Format changes

`Format()` now uses a consistent `<uuid> <name>` representation for the `%s` verb, with `?` as a placeholder when the name is empty. This makes invalid identities clearly distinguishable in diagnostic output.

## Allocation characteristics

- `MarshalText`: 2 allocations (UUID text intermediate + grown result buffer)
- `UnmarshalText`: 2 allocations (name string + UUID)